### PR TITLE
Improve VFS simple's discovery of registered backends

### DIFF
--- a/docs/vfssimple.md
+++ b/docs/vfssimple.md
@@ -14,45 +14,74 @@ supported backend filesystem by using full URI's:
 
 Just import vfssimple.
 
-      package main
-
-      import(
-    	"github.com/c2fo/vfs/vfssimple"
-      )
-
-      ...
-
-      func DoSomething() error {
+    package main
+    
+    import(
+        "github.com/c2fo/vfs/vfssimple"
+    )
+    
+    ...
+    
+    func DoSomething() error {
         myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
         if err != nil {
             return err
         }
-
+        
         myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
         if err != nil {
             return err
         }
-
+        
         localFile, err := myS3File.MoveToLocation(myLocalDir)
         if err != nil {
             return err
         }
-
-      }
+    }
 
 
 ### Authentication and Options
 
-vfssimple is largely an example of how to initialize a set of backend
-filesystems. It only provides a default initialization of the individual file
-systems. See backend docs for specific authentication info for each backend but
-generally speaking, most backends can use Environment variables to set
-credentials or client options.
+vfssimple is largely an example of how to initialize a set of backend filesystems.  It only provides a default
+initialization of the individual file systems.  See backend docs for specific authentication info for each backend but
+generally speaking, most backends can use Environment variables to set credentials or client options.
 
-To do more, especially if you need to pass in specific [vfs.Options](../README.md#type-options)'s via
-WithOption() or perhaps a mock client for testing via WithClient() or something
-else, you'd need to implement your own factory. See [backend](backend.md)
-for more information.
+File systems can only use one set of options. If you would like to configure more than one file system of the same type/schema with separate credentials,
+you can register and map file system options to locations or individual objects. The vfssimple library will automatically try to
+resolve the provided URI in NewFile() or NewLocation() to the registered file system.
+
+    package main
+    
+    import(
+        "github.com/c2fo/vfs/vfssimple"
+        "github.com/c2fo/vfs/backend"
+        "github.com/c2fo/vfs/backend/s3"
+    )
+    
+    ...
+    
+    func DoSomething() error {
+        bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
+            AccessKeyID:     "key1",
+            SecretAccessKey: "secret1,
+            Region:          "us-west-2",
+        })
+        
+        fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
+            AccessKeyID:     "key2",
+            SecretAccessKey: "secret2,
+            Region:          "us-west-2",
+        })
+        
+        backend.Register("s3://bucket1/, bucketAuth)
+        backend.Register("s3://bucket2/file.txt, fileAuth)
+        
+        secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
+        publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
+        
+        secureFile.CopyToLocation(publicLocation)
+    }
+
 
 ## Functions
 

--- a/vfssimple/doc.go
+++ b/vfssimple/doc.go
@@ -40,6 +40,41 @@ vfssimple is largely an example of how to initialize a set of backend filesystem
 initialization of the individual file systems.  See backend docs for specific authentication info for each backend but
 generally speaking, most backends can use Environment variables to set credentials or client options.
 
+File systems can only use one set of options. If you would like to configure more than one file system of the same type/schema with separate credentials,
+you can register and map file system options to locations or individual objects. The vfssimple library will automatically try to
+resolve the provided URI in NewFile() or NewLocation() to the registered file system.
+
+  package main
+
+  import(
+	"github.com/c2fo/vfs/vfssimple"
+	"github.com/c2fo/vfs/backend/s3"
+  )
+
+  ...
+
+  func DoSomething() error {
+	bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
+		AccessKeyID:     "key1",
+		SecretAccessKey: "secret1,
+		Region:          "us-west-2",
+	})
+
+	fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
+		AccessKeyID:     "key2",
+		SecretAccessKey: "secret2,
+		Region:          "us-west-2",
+	})
+
+	backend.Register("s3://bucket1/, bucket1)
+	backend.Register("s3://bucket2/file.txt, fileAuth)
+
+    secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
+	publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
+
+	secureFile.CopyToLocation(publicLocation)
+  }
+
 To do more, especially if you need to pass in specific vfs.Option's via WithOption() or perhaps a mock client for testing via
 WithClient() or something else, you'd need to implement your own factory.  See github.com/c2fo/vfs/backend for more information.
 */

--- a/vfssimple/doc.go
+++ b/vfssimple/doc.go
@@ -48,6 +48,7 @@ resolve the provided URI in NewFile() or NewLocation() to the registered file sy
 
   import(
 	"github.com/c2fo/vfs/vfssimple"
+	"github.com/c2fo/vfs/backend"
 	"github.com/c2fo/vfs/backend/s3"
   )
 
@@ -66,10 +67,10 @@ resolve the provided URI in NewFile() or NewLocation() to the registered file sy
 		Region:          "us-west-2",
 	})
 
-	backend.Register("s3://bucket1/, bucket1)
+	backend.Register("s3://bucket1/, bucketAuth)
 	backend.Register("s3://bucket2/file.txt, fileAuth)
 
-    secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
+	secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
 	publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
 
 	secureFile.CopyToLocation(publicLocation)

--- a/vfssimple/doc.go
+++ b/vfssimple/doc.go
@@ -76,7 +76,5 @@ resolve the provided URI in NewFile() or NewLocation() to the registered file sy
 	secureFile.CopyToLocation(publicLocation)
   }
 
-To do more, especially if you need to pass in specific vfs.Option's via WithOption() or perhaps a mock client for testing via
-WithClient() or something else, you'd need to implement your own factory.  See github.com/c2fo/vfs/backend for more information.
 */
 package vfssimple

--- a/vfssimple/vfssimple.go
+++ b/vfssimple/vfssimple.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/c2fo/vfs"
 	"github.com/c2fo/vfs/backend"
@@ -46,6 +47,18 @@ func parseSupportedURI(uri string) (vfs.FileSystem, string, string, error) {
 
 	var fs vfs.FileSystem
 	for _, backendScheme := range backend.RegisteredBackends() {
+		// Object-level backend
+		if strings.Index(uri, backendScheme) > 1 {
+			fs = backend.Backend(backendScheme)
+			break
+		}
+		// Bucket-level backend
+		volume := fmt.Sprintf("%s://%s/", u.Scheme, u.Host)
+		if volume == backendScheme {
+			fs = backend.Backend(backendScheme)
+			break
+		}
+		// Scheme-level backend
 		if u.Scheme == backendScheme {
 			fs = backend.Backend(backendScheme)
 		}


### PR DESCRIPTION
VFS simple currently assumes that you only want one default backend for each implementation (s3/gcs/os). This change will allow you to register backends based on URIs. It starts by searching for a backend based on a file URI, then falls back to bucket/volume, and finally falls back to the URI scheme.