### PR TITLE
Fix leading slash bug for GCS location.Path()

### DIFF
--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -88,6 +88,9 @@ func (l *Location) Volume() string {
 
 // Path returns the path of the file at the current location, starting with a leading '/'
 func (l *Location) Path() string {
+	if strings.Index(l.prefix, "/") == 0 {
+		return utils.EnsureTrailingSlash(l.prefix)
+	}
 	return "/" + utils.EnsureTrailingSlash(l.prefix)
 }
 


### PR DESCRIPTION
I fixed the issue where there is a leading slash when calling location.Path() for GCS locations. I also improved the discoverability of registered filesystems at the location-level.