### PR TITLE
Add ability to set a retrier for remote file systems

### DIFF
--- a/backend/all/all.go
+++ b/backend/all/all.go
@@ -2,7 +2,13 @@
 package all
 
 import (
+	"github.com/c2fo/vfs/v3"
 	_ "github.com/c2fo/vfs/v3/backend/gs" // register gs backend
 	_ "github.com/c2fo/vfs/v3/backend/os" // register os backend
 	_ "github.com/c2fo/vfs/v3/backend/s3" // register s3 backend
 )
+
+// DefaultRetrier returns a no-op retryer which simply calls the wrapped command without looping.
+func DefaultRetrier() vfs.Retry {
+	return func(c func() error) error { return c() }
+}

--- a/backend/all/all.go
+++ b/backend/all/all.go
@@ -2,13 +2,7 @@
 package all
 
 import (
-	"github.com/c2fo/vfs/v3"
 	_ "github.com/c2fo/vfs/v3/backend/gs" // register gs backend
 	_ "github.com/c2fo/vfs/v3/backend/os" // register os backend
 	_ "github.com/c2fo/vfs/v3/backend/s3" // register s3 backend
 )
-
-// DefaultRetrier returns a no-op retryer which simply calls the wrapped command without looping.
-func DefaultRetrier() vfs.Retry {
-	return func(c func() error) error { return c() }
-}

--- a/backend/gs/bucketHandleWrapper.go
+++ b/backend/gs/bucketHandleWrapper.go
@@ -6,10 +6,17 @@ import (
 	"github.com/c2fo/vfs/v3"
 )
 
+// BucketHandle is an interface which contains a subset of the functions provided
+// by storage.BucketHandler. Any function normally called directly by storage.BucketHandler
+// should be added to this interface to allow for proper retry wrapping of the functions
+// which call the GCS API.
 type BucketHandle interface {
 	Attrs(ctx context.Context) (*storage.BucketAttrs, error)
 }
 
+// BucketHandleWrapper is a unique, wrapped type which should mimic the behavior of BucketHandler, but with
+// modified return types. Each function that returns a sub type that also should be wrapped should be added
+// to this interface with the 'Wrapped' prefix.
 type BucketHandleWrapper interface {
 	BucketHandle
 	WrappedObjects(ctx context.Context, q *storage.Query) ObjectIteratorWrapper
@@ -30,6 +37,7 @@ func (r *RetryBucketHandler) WrappedObjects(ctx context.Context, q *storage.Quer
 	return &RetryObjectIterator{Retry: r.Retry, iterator: r.handler.Objects(ctx, q)}
 }
 
+// ObjectIteratorWrapper is an interface which contains a subset of the functions provided by storage.ObjectIterator.
 type ObjectIteratorWrapper interface {
 	Next() (*storage.ObjectAttrs, error)
 }

--- a/backend/gs/bucketHandleWrapper.go
+++ b/backend/gs/bucketHandleWrapper.go
@@ -1,0 +1,61 @@
+package gs
+
+import (
+	"cloud.google.com/go/storage"
+	"context"
+	"github.com/c2fo/vfs/v3"
+)
+
+type BucketHandle interface {
+	Attrs(ctx context.Context) (*storage.BucketAttrs, error)
+}
+
+type BucketHandleWrapper interface {
+	BucketHandle
+	WrappedObjects(ctx context.Context, q *storage.Query) ObjectIteratorWrapper
+}
+
+type RetryBucketHandler struct {
+	Retry   vfs.Retry
+	handler *storage.BucketHandle
+}
+
+func (r *RetryBucketHandler) Attrs(ctx context.Context) (*storage.BucketAttrs, error) {
+	return bucketAttributeRetry(r.Retry, func() (*storage.BucketAttrs, error) {
+		return r.handler.Attrs(ctx)
+	})
+}
+
+func (r *RetryBucketHandler) WrappedObjects(ctx context.Context, q *storage.Query) ObjectIteratorWrapper {
+	return &RetryObjectIterator{Retry: r.Retry, iterator: r.handler.Objects(ctx, q)}
+}
+
+type ObjectIteratorWrapper interface {
+	Next() (*storage.ObjectAttrs, error)
+}
+
+type RetryObjectIterator struct {
+	Retry    vfs.Retry
+	iterator *storage.ObjectIterator
+}
+
+func (r *RetryObjectIterator) Next() (*storage.ObjectAttrs, error) {
+	return objectAttributeRetry(r.Retry, func() (*storage.ObjectAttrs, error) {
+		return r.iterator.Next()
+	})
+}
+
+func bucketAttributeRetry(retry vfs.Retry, attrFunc func() (*storage.BucketAttrs, error)) (*storage.BucketAttrs, error) {
+	var attrs *storage.BucketAttrs
+	if err := retry(func() error {
+		var retryErr error
+		attrs, retryErr = attrFunc()
+		if retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}

--- a/backend/gs/file.go
+++ b/backend/gs/file.go
@@ -336,7 +336,7 @@ func (f *File) copyWithinGCSToFile(targetFile *File) error {
 		return err
 	}
 	// Copy content and modify metadata.
-	copier := tHandle.WrappedCopierFrom(fHandle)
+	copier := tHandle.WrappedCopierFrom(fHandle.ObjectHandle())
 	attrs, gerr := f.getObjectAttrs()
 	if gerr != nil {
 		return gerr
@@ -348,7 +348,7 @@ func (f *File) copyWithinGCSToFile(targetFile *File) error {
 	}
 
 	// Just copy content.
-	_, err = tHandle.WrappedCopierFrom(fHandle).Run(f.fileSystem.ctx)
+	_, err = tHandle.WrappedCopierFrom(fHandle.ObjectHandle()).Run(f.fileSystem.ctx)
 	return nil
 }
 

--- a/backend/gs/file.go
+++ b/backend/gs/file.go
@@ -323,11 +323,7 @@ func (f *File) getObjectAttrs() (*storage.ObjectAttrs, error) {
 	if err != nil {
 		return nil, err
 	}
-	attrs, err := handle.Attrs(f.fileSystem.ctx)
-	if err != nil {
-		return nil, err
-	}
-	return attrs, nil
+	return handle.Attrs(f.fileSystem.ctx)
 }
 
 func (f *File) copyWithinGCSToFile(targetFile *File) error {
@@ -353,9 +349,6 @@ func (f *File) copyWithinGCSToFile(targetFile *File) error {
 
 	// Just copy content.
 	_, err = tHandle.WrappedCopierFrom(fHandle).Run(f.fileSystem.ctx)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/backend/gs/file.go
+++ b/backend/gs/file.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/c2fo/goutils/errorstack"
 	"io"
 	"io/ioutil"
 	"os"
@@ -33,35 +34,41 @@ type File struct {
 // Close cleans up underlying mechanisms for reading from and writing to the file. Closes and removes the
 // local temp file, and triggers a write to GCS of anything in the f.writeBuffer if it has been created.
 func (f *File) Close() error {
-	if f.tempFile != nil {
-		defer f.tempFile.Close()
+	if err := f.fileSystem.Retry()(func() error {
+		if f.tempFile != nil {
+			defer f.tempFile.Close()
 
-		err := os.Remove(f.tempFile.Name())
-		if err != nil && !os.IsNotExist(err) {
-			return err
+			err := os.Remove(f.tempFile.Name())
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+
+			f.tempFile = nil
 		}
 
-		f.tempFile = nil
+		if f.writeBuffer != nil {
+
+			handle, err := f.getObjectHandle()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithCancel(f.fileSystem.ctx)
+			defer func() { cancel() }()
+			w := handle.NewWriter(ctx)
+			defer w.Close()
+			if _, err := io.Copy(w, f.writeBuffer); err != nil {
+				//cancel context (replaces CloseWithError)
+				return err
+			}
+		}
+
+		f.writeBuffer = nil
+		return nil
+	}); err != nil {
+		return err
 	}
 
-	if f.writeBuffer != nil {
-
-		handle, err := f.getObjectHandle()
-		if err != nil {
-			return err
-		}
-
-		ctx, cancel := context.WithCancel(f.fileSystem.ctx)
-		defer func() { cancel() }()
-		w := handle.NewWriter(ctx)
-		defer w.Close()
-		if _, err := io.Copy(w, f.writeBuffer); err != nil {
-			//cancel context (replaces CloseWithError)
-			return err
-		}
-	}
-
-	f.writeBuffer = nil
 	return nil
 }
 
@@ -256,13 +263,19 @@ func (f *File) URI() string {
 }
 
 func (f *File) checkTempFile() error {
-	if f.tempFile == nil {
-		localTempFile, err := f.copyToLocalTempReader()
-		if err != nil {
-			return err
+	if err := f.fileSystem.Retry()(func() error {
+		if f.tempFile == nil {
+			localTempFile, err := f.copyToLocalTempReader()
+			if err != nil {
+				return err
+			}
+			f.tempFile = localTempFile
 		}
-		f.tempFile = localTempFile
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return nil
 }
 
@@ -313,38 +326,54 @@ func (f *File) getObjectHandle() (*storage.ObjectHandle, error) {
 
 // getObjectAttrs returns the file's attributes
 func (f *File) getObjectAttrs() (*storage.ObjectAttrs, error) {
-	handle, err := f.getObjectHandle()
-	if err != nil {
-		return nil, err
+	var attrs *storage.ObjectAttrs
+
+	if err := f.fileSystem.Retry()(func() error {
+		handle, err := f.getObjectHandle()
+		if err != nil {
+			return err
+		}
+		attrs, err = handle.Attrs(f.fileSystem.ctx)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return attrs, err
 	}
-	return handle.Attrs(f.fileSystem.ctx)
+
+	return attrs, nil
 }
 
 func (f *File) copyWithinGCSToFile(targetFile *File) error {
-	tHandle, err := targetFile.getObjectHandle()
-	if err != nil {
+	if err := f.fileSystem.Retry()(func() error {
+		tHandle, err := targetFile.getObjectHandle()
+		if err != nil {
+			return err
+		}
+		fHandle, err := f.getObjectHandle()
+		if err != nil {
+			return err
+		}
+		// Copy content and modify metadata.
+		copier := tHandle.CopierFrom(fHandle)
+		attrs, gerr := f.getObjectAttrs()
+		if gerr != nil {
+			return gerr
+		}
+		copier.ContentType = attrs.ContentType
+		_, cerr := copier.Run(f.fileSystem.ctx)
+		if cerr != nil {
+			return cerr
+		}
+
+		// Just copy content.
+		_, err = tHandle.CopierFrom(fHandle).Run(f.fileSystem.ctx)
+		return err
+	}); err != nil {
 		return err
 	}
-	fHandle, err := f.getObjectHandle()
-	if err != nil {
-		return err
-	}
-	// Copy content and modify metadata.
-	copier := tHandle.CopierFrom(fHandle)
-	attrs, gerr := f.getObjectAttrs()
-	if gerr != nil {
-		return gerr
-	}
-	copier.ContentType = attrs.ContentType
-	_, cerr := copier.Run(f.fileSystem.ctx)
-	if cerr != nil {
-		return cerr
-	}
-
-	// Just copy content.
-	_, err = tHandle.CopierFrom(fHandle).Run(f.fileSystem.ctx)
-
-	return err
+	return nil
 }
 
 /* private helper functions */

--- a/backend/gs/fileSystem.go
+++ b/backend/gs/fileSystem.go
@@ -2,6 +2,7 @@ package gs
 
 import (
 	"cloud.google.com/go/storage"
+	"github.com/c2fo/vfs/v3/backend/all"
 	"golang.org/x/net/context"
 
 	"github.com/c2fo/vfs/v3"
@@ -18,6 +19,14 @@ type FileSystem struct {
 	client  *storage.Client
 	ctx     context.Context
 	options vfs.Options
+}
+
+// FileSystem will return a retrier provided via options, or a no-op if none is provided.
+func (fs *FileSystem) Retry() vfs.Retry {
+	if fs.options.(*Options).Retry != nil {
+		return fs.options.(*Options).Retry
+	}
+	return all.DefaultRetrier()
 }
 
 // NewFile function returns the gcs implementation of vfs.File.

--- a/backend/gs/fileSystem.go
+++ b/backend/gs/fileSystem.go
@@ -2,7 +2,6 @@ package gs
 
 import (
 	"cloud.google.com/go/storage"
-	"github.com/c2fo/vfs/v3/backend/all"
 	"golang.org/x/net/context"
 
 	"github.com/c2fo/vfs/v3"
@@ -23,10 +22,10 @@ type FileSystem struct {
 
 // FileSystem will return a retrier provided via options, or a no-op if none is provided.
 func (fs *FileSystem) Retry() vfs.Retry {
-	if fs.options.(*Options).Retry != nil {
-		return fs.options.(*Options).Retry
+	if options, _ := fs.options.(Options); options.Retry != nil {
+		return options.Retry
 	}
-	return all.DefaultRetrier()
+	return vfs.DefaultRetryer()
 }
 
 // NewFile function returns the gcs implementation of vfs.File.

--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -170,10 +170,5 @@ func (l *Location) getBucketAttrs() (*storage.BucketAttrs, error) {
 		return nil, err
 	}
 
-	attrs, err := handle.Attrs(l.fileSystem.ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return attrs, nil
+	return handle.Attrs(l.fileSystem.ctx)
 }

--- a/backend/gs/objectHandleWrapper.go
+++ b/backend/gs/objectHandleWrapper.go
@@ -22,7 +22,8 @@ type ObjectHandleWrapper interface {
 // to this interface with the 'Wrapped' prefix.
 type ObjectHandleCopier interface {
 	ObjectHandleWrapper
-	WrappedCopierFrom(src ObjectHandleWrapper) CopierWrapper
+	WrappedCopierFrom(src *storage.ObjectHandle) CopierWrapper
+	ObjectHandle() *storage.ObjectHandle
 }
 
 // CopierWrapper is an interface which contains a subset of the functions provided by storage.Copier.
@@ -34,6 +35,10 @@ type CopierWrapper interface {
 type RetryObjectHandler struct {
 	Retry   vfs.Retry
 	handler *storage.ObjectHandle
+}
+
+func (r *RetryObjectHandler) ObjectHandle() *storage.ObjectHandle {
+	return r.handler
 }
 
 func (r *RetryObjectHandler) NewWriter(ctx context.Context) *storage.Writer {
@@ -73,8 +78,8 @@ func (r *RetryObjectHandler) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (r *RetryObjectHandler) WrappedCopierFrom(src ObjectHandleWrapper) CopierWrapper {
-	return &Copier{copier: r.handler.CopierFrom(src.(*storage.ObjectHandle)), Retry: r.Retry}
+func (r *RetryObjectHandler) WrappedCopierFrom(src *storage.ObjectHandle) CopierWrapper {
+	return &Copier{copier: r.handler.CopierFrom(src), Retry: r.Retry}
 }
 
 type Copier struct {

--- a/backend/gs/objectHandleWrapper.go
+++ b/backend/gs/objectHandleWrapper.go
@@ -1,0 +1,107 @@
+package gs
+
+import (
+	"cloud.google.com/go/storage"
+	"context"
+	"github.com/c2fo/vfs/v3"
+)
+
+// ObjectHandleWrapper is an interface which contains a subset of the functions provided
+// by storage.ObjectHandler. Any function normally called directly by storage.ObjectHandler
+// should be added to this interface to allow for proper retry wrapping of the functions
+// which call the GCS API.
+type ObjectHandleWrapper interface {
+	NewWriter(ctx context.Context) *storage.Writer
+	NewReader(ctx context.Context) (*storage.Reader, error)
+	Attrs(ctx context.Context) (*storage.ObjectAttrs, error)
+	Delete(ctx context.Context) error
+}
+
+// ObjectHandleCopier is a unique, wrapped type which should mimic the behavior of ObjectHandler, but with
+// modified return types. Each function that returns a sub type that also should be wrapped should be added
+// to this interface with the 'Wrapped' prefix.
+type ObjectHandleCopier interface {
+	ObjectHandleWrapper
+	WrappedCopierFrom(src ObjectHandleWrapper) CopierWrapper
+}
+
+// CopierWrapper is an interface which contains a subset of the functions provided by storage.Copier.
+type CopierWrapper interface {
+	Run(ctx context.Context) (*storage.ObjectAttrs, error)
+	ContentType(string)
+}
+
+type RetryObjectHandler struct {
+	Retry   vfs.Retry
+	handler *storage.ObjectHandle
+}
+
+func (r *RetryObjectHandler) NewWriter(ctx context.Context) *storage.Writer {
+	return r.handler.NewWriter(ctx)
+}
+
+func (r *RetryObjectHandler) NewReader(ctx context.Context) (*storage.Reader, error) {
+	var reader *storage.Reader
+	if err := r.Retry(func() error {
+		var retryErr error
+		reader, retryErr = r.handler.NewReader(ctx)
+		if retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return reader, nil
+}
+
+func (r *RetryObjectHandler) Attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
+	var attrs *storage.ObjectAttrs
+	if err := r.Retry(func() error {
+		var retryErr error
+		attrs, retryErr = r.handler.Attrs(ctx)
+		if retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}
+
+func (r *RetryObjectHandler) Delete(ctx context.Context) error {
+	if err := r.Retry(func() error {
+		if retryErr := r.handler.Delete(ctx); retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RetryObjectHandler) WrappedCopierFrom(src ObjectHandleWrapper) CopierWrapper {
+	return &Copier{copier: r.handler.CopierFrom(src.(*storage.ObjectHandle)), Retry: r.Retry}
+}
+
+type Copier struct {
+	copier *storage.Copier
+	Retry  vfs.Retry
+}
+
+func (c *Copier) Run(ctx context.Context) (*storage.ObjectAttrs, error) {
+	var attrs *storage.ObjectAttrs
+	if err := c.Retry(func() error {
+		var retryErr error
+		attrs, retryErr = c.copier.Run(ctx)
+		if retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}

--- a/backend/gs/options.go
+++ b/backend/gs/options.go
@@ -12,6 +12,7 @@ type Options struct {
 	CredentialFile string   `json:"credentialFilePath,omitempty"`
 	Endpoint       string   `json:"endpoint,omitempty"`
 	Scopes         []string `json:"WithoutAuthentication,omitempty"`
+	Retry          vfs.Retry
 }
 
 func parseClientOptions(opts vfs.Options) []option.ClientOption {

--- a/backend/os/fileSystem.go
+++ b/backend/os/fileSystem.go
@@ -3,6 +3,7 @@ package os
 import (
 	"github.com/c2fo/vfs/v3"
 	"github.com/c2fo/vfs/v3/backend"
+	"github.com/c2fo/vfs/v3/backend/all"
 	"github.com/c2fo/vfs/v3/utils"
 )
 
@@ -12,6 +13,11 @@ const name = "os"
 
 // FileSystem implements vfs.Filesystem for the OS filesystem.
 type FileSystem struct{}
+
+// FileSystem will return a retrier provided via options, or a no-op if none is provided.
+func (fs *FileSystem) Retry() vfs.Retry {
+	return all.DefaultRetrier()
+}
 
 // NewFile function returns the os implementation of vfs.File.
 func (fs *FileSystem) NewFile(volume string, name string) (vfs.File, error) {

--- a/backend/os/fileSystem.go
+++ b/backend/os/fileSystem.go
@@ -3,7 +3,6 @@ package os
 import (
 	"github.com/c2fo/vfs/v3"
 	"github.com/c2fo/vfs/v3/backend"
-	"github.com/c2fo/vfs/v3/backend/all"
 	"github.com/c2fo/vfs/v3/utils"
 )
 
@@ -16,7 +15,7 @@ type FileSystem struct{}
 
 // FileSystem will return a retrier provided via options, or a no-op if none is provided.
 func (fs *FileSystem) Retry() vfs.Retry {
-	return all.DefaultRetrier()
+	return vfs.DefaultRetryer()
 }
 
 // NewFile function returns the os implementation of vfs.File.

--- a/backend/s3/fileSystem.go
+++ b/backend/s3/fileSystem.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/c2fo/vfs/v3/backend/all"
 
 	"github.com/c2fo/vfs/v3"
 	"github.com/c2fo/vfs/v3/backend"
@@ -18,6 +19,14 @@ const name = "AWS S3"
 type FileSystem struct {
 	client  s3iface.S3API
 	options vfs.Options
+}
+
+// FileSystem will return a retrier provided via options, or a no-op if none is provided.
+func (fs *FileSystem) Retry() vfs.Retry {
+	if fs.options.(*Options).Retrier != nil {
+		return fs.options.(*Options).Retrier
+	}
+	return all.DefaultRetrier()
 }
 
 // NewFile function returns the s3 implementation of vfs.File.

--- a/backend/s3/fileSystem.go
+++ b/backend/s3/fileSystem.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/c2fo/vfs/v3/backend/all"
-
 	"github.com/c2fo/vfs/v3"
 	"github.com/c2fo/vfs/v3/backend"
 	"github.com/c2fo/vfs/v3/utils"
@@ -21,12 +19,10 @@ type FileSystem struct {
 	options vfs.Options
 }
 
-// FileSystem will return a retrier provided via options, or a no-op if none is provided.
+// FileSystem will return the default no-op retrier. The S3 client provides its own retryer interface, and is available
+// to override via the s3.FileSystem Options type.
 func (fs *FileSystem) Retry() vfs.Retry {
-	if fs.options.(*Options).Retrier != nil {
-		return fs.options.(*Options).Retrier
-	}
-	return all.DefaultRetrier()
+	return vfs.DefaultRetryer()
 }
 
 // NewFile function returns the s3 implementation of vfs.File.

--- a/backend/s3/options.go
+++ b/backend/s3/options.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"github.com/c2fo/vfs/v3"
 	"net/http"
 	"os"
 	"time"
@@ -22,6 +23,7 @@ type Options struct {
 	SessionToken    string `json:"sessionToken,omitempty"`
 	Region          string `json:"region,omitempty"`
 	Endpoint        string `json:"endpoint,omitempty"`
+	Retrier         vfs.Retry
 }
 
 // getClient setup S3 client

--- a/backend/s3/options.go
+++ b/backend/s3/options.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"github.com/c2fo/vfs/v3"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"net/http"
 	"os"
 	"time"
@@ -23,7 +23,8 @@ type Options struct {
 	SessionToken    string `json:"sessionToken,omitempty"`
 	Region          string `json:"region,omitempty"`
 	Endpoint        string `json:"endpoint,omitempty"`
-	Retrier         vfs.Retry
+	Retry           request.Retryer
+	MaxRetries      int
 }
 
 // getClient setup S3 client
@@ -41,6 +42,10 @@ func getClient(opt Options) (s3iface.S3API, error) {
 
 	//use specific endpoint, otherwise, will use aws "default endpoint resolver" based on region
 	awsConfig.WithEndpoint(opt.Endpoint)
+
+	if opt.Retry != nil {
+		awsConfig.Retryer = opt.Retry
+	}
 
 	//set up credential provider chain
 	credentialProviders, err := initCredentialProviderChain(opt)

--- a/backend/s3/options.go
+++ b/backend/s3/options.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"github.com/aws/aws-sdk-go/aws/request"
 	"net/http"
 	"os"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"

--- a/docs/vfssimple.md
+++ b/docs/vfssimple.md
@@ -82,6 +82,35 @@ resolve the provided URI in NewFile() or NewLocation() to the registered file sy
         secureFile.CopyToLocation(publicLocation)
     }
 
+### Retry Option
+
+This option allows you to specify a custom retry method which backend implementations can choose to utilize
+when calling remote file systems. This adds some flexibility in how a retry on file operations should be handled.
+
+    package main
+    
+    import(
+        "time"
+        
+        "github.com/c2fo/vfs/backend"
+        "github.com/c2fo/vfs/backend/gs"
+    )
+    
+    ...
+    
+    func InitializeWithRetry() error {
+        bucketAuth := gs.NewFileSystem().WithOptions(gs.Options{
+            Retry: func(wrapper func() error) error {
+                for i := 0; i < 5; i++ {
+                    if err := wrapper(); err != nil {
+                        time.Sleep(1 * time.Second)
+                        continue
+                    }
+                }
+            },
+        })
+    }
+
 
 ## Functions
 

--- a/mocks/FileSystem.go
+++ b/mocks/FileSystem.go
@@ -8,6 +8,19 @@ type FileSystem struct {
 	mock.Mock
 }
 
+func (_m *FileSystem) Retry() vfs.Retry {
+	ret := _m.Called()
+
+	var r0 vfs.Retry
+	if rf, ok := ret.Get(0).(func() vfs.Retry); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(vfs.Retry)
+	}
+
+	return r0
+}
+
 // Name provides a mock function with given fields:
 func (_m *FileSystem) Name() string {
 	ret := _m.Called()

--- a/vfs.go
+++ b/vfs.go
@@ -154,3 +154,8 @@ type Options interface{}
 //    return ret
 // }
 type Retry func(wrapped func() error) error
+
+// DefaultRetryer returns a no-op retryer which simply calls the wrapped command without looping.
+func DefaultRetryer() Retry {
+	return func(c func() error) error { return c() }
+}

--- a/vfs.go
+++ b/vfs.go
@@ -29,6 +29,9 @@ type FileSystem interface {
 
 	// Scheme, related to Name, is the uri scheme used by the FileSystem: s3, file, gs, etc...
 	Scheme() string
+
+	// Retry will return the retry function to be used by any file system.
+	Retry() Retry
 }
 
 // Location represents a filesystem path which serves as a start point for directory-like functionality.  A location may
@@ -138,3 +141,16 @@ type File interface {
 
 // Options are structs that contain various options specific to the filesystem
 type Options interface{}
+
+// Retry is a function that can be used to wrap any operation into a definable retry operation. The wrapped argument
+// is called by the underlying VFS implementation.
+//
+// Ex:
+// var retrier Retry = func(wrapped func() error) error {
+//    var ret error
+//    for i := 0; i < 5; i++ {
+//       if err := wrapped(); err != nil { ret = err; continue }
+//    }
+//    return ret
+// }
+type Retry func(wrapped func() error) error


### PR DESCRIPTION
This change covers a new interface which allows implementers to define a generic retrier in the event that the underlying file system client does not provide a retrier interface of their own. Retriers can be assigned via the filesystem options.