### PR TITLE
Fix os.File.MoveToLocation()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [5.2.2] - 2019-07-17
+### Fixed
+- The OS implementation of file.MoveToLocation() now ensures that the target directory exists before attempting to move the file
+
 ## [5.2.1] - 2019-07-17
 ### Fixed
 - Missing error check in utils.UpdateLastModifiedByMoving()

--- a/backend/os/file.go
+++ b/backend/os/file.go
@@ -164,6 +164,9 @@ func (f *File) MoveToFile(file vfs.File) error {
 func (f *File) MoveToLocation(location vfs.Location) (vfs.File, error) {
 	// handle native os move/rename
 	if location.FileSystem().Scheme() == Scheme {
+		if err := ensureDir(location); err != nil {
+			return nil, err
+		}
 		err := os.Rename(f.Path(), path.Join(location.Path(), f.Name()))
 		if err != nil {
 			return nil, err
@@ -260,4 +263,15 @@ func (f *File) openFile() (*os.File, error) {
 	file, err := os.OpenFile(f.Path(), os.O_RDWR|os.O_CREATE, fileMode)
 	f.file = file
 	return file, err
+}
+
+func ensureDir(location vfs.Location) error {
+	if exists, err := location.Exists(); err != nil {
+		return err
+	} else if !exists {
+		if err := os.MkdirAll(location.Path(), os.ModeDir|0777); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/testsuite/backend_integration_test.go
+++ b/backend/testsuite/backend_integration_test.go
@@ -658,6 +658,22 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 		//   * In the case of an error, nil is returned for the file.
 		//   * When moving within the same Scheme, native move/rename should be used where possible.
 		//   * If the file already exists, the contents will be overwritten with the current file's contents.
+		fileForNew, err := srcLoc.NewFile("fileForNew.txt")
+		s.NoError(err)
+
+		_, err = srcFile.Seek(0, 0)
+		s.NoError(err)
+		_, err = io.Copy(fileForNew, srcFile)
+		s.NoError(err)
+
+		newLoc, err := dstLoc.NewLocation("doesnotexist/")
+		s.NoError(err)
+		dstCopyNew, err := fileForNew.MoveToLocation(newLoc)
+		s.NoError(err)
+		exists, err = dstCopyNew.Exists()
+		s.NoError(err)
+		s.True(exists)
+
 		dstCopy1, err := copyFile1.MoveToLocation(dstLoc)
 		s.NoError(err)
 		// destination file should now exist


### PR DESCRIPTION
The underlying os.Rename() function was throwing errors when attempting to move files to directories that do not exist. This change will ensure the directory exists before doing the Rename() call.