### PR TITLE
ACL can now be passed in as an s3.Option value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2019-08-24
+### Added
+- ACL can now be passed in as an s3.Option value. See 
+https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl for values.
+
 ## [5.2.3] - 2019-08-07
 ### Fixed
 - The GS implementation of location.List() returned an empty string for files found inside a persistent "folder" object

--- a/backend/s3/doc.go
+++ b/backend/s3/doc.go
@@ -40,6 +40,7 @@ would have to be cast as s3.FileSystem to use the following:
               AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
               SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
               Region:          "us-west-2",
+              ACL: 			   "bucket-owner-full-control",
           },
       )
 
@@ -51,6 +52,11 @@ would have to be cast as s3.FileSystem to use the following:
               }, nil)
       fs = fs.WithClient(s3apiMock)
   }
+
+Object ACL
+
+Canned ACL's can be passed in as an Option.  This string will be applied to all writes, moves, and copies.
+See https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl for values.
 
 Authentication
 

--- a/backend/s3/options.go
+++ b/backend/s3/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	SessionToken    string `json:"sessionToken,omitempty"`
 	Region          string `json:"region,omitempty"`
 	Endpoint        string `json:"endpoint,omitempty"`
+	ACL             string `json:"acl,omitempty"`
 	Retry           request.Retryer
 	MaxRetries      int
 }

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -45,6 +45,7 @@ use the following:
                 AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
                 SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                 Region:          "us-west-2",
+                ACL:             "bucket-owner-full-control",
             },
         )
 
@@ -57,6 +58,11 @@ use the following:
         fs = fs.WithClient(s3apiMock)
     }
 
+
+### Object ACL
+
+Canned ACL's can be passed in as an Option.  This string will be applied to all writes, moves, and copies.
+See https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl for values.
 
 ### Authentication
 


### PR DESCRIPTION
### Added
- ACL can now be passed in as an s3.Option value. See https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl for values.