### PR TITLE
Fix space issue

### DIFF
--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -149,7 +149,7 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 
 	length := len(f.contents)
 
-	if num := int64(length) + int64(offset) + int64(whence); num == 0 {
+	if num := int64(length) + offset + int64(whence); num == 0 {
 		return 0, nil
 	}
 	switch whence {

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"time"
@@ -90,10 +91,24 @@ func (f *File) Location() vfs.Location {
 // CopyToFile puts the contents of File into the targetFile passed. Uses the S3 CopyObject
 // method if the target file is also on S3, otherwise uses io.Copy.
 func (f *File) CopyToFile(file vfs.File) error {
+	//if target is S3
 	if tf, ok := file.(*File); ok {
-		return f.copyFile(tf)
+		input, err := f.getCopyObjectInput(tf)
+		if err != nil {
+			return err
+		}
+		//if input is not nil, use it to natively copy object
+		if input != nil {
+			client, err := f.fileSystem.Client()
+			if err != nil {
+				return err
+			}
+			_, err = client.CopyObject(input)
+			return err
+		}
 	}
 
+	//otherwise use TouchCopy (io.Copy)
 	if err := utils.TouchCopy(file, f); err != nil {
 		return err
 	}
@@ -287,48 +302,56 @@ func (f *File) getHeadObject() (*s3.HeadObjectOutput, error) {
 	return client.HeadObject(headObjectInput)
 }
 
-// Copy from S3-to-S3 when accounts are the same between source and target and fall back to a
-// TouchCopy() call if they are different.
-func (f *File) copyFile(targetFile *File) error {
+// For copy from S3-to-S3 when credentials are the same between source and target, return *s3.CopyObjectInput or error
+func (f *File) getCopyObjectInput(targetFile *File) (*s3.CopyObjectInput, error) {
+	//first we must determine if we're using the same s3 credentials for source and target before doing a native copy
 	isSameAccount := false
-	hasACLOption := false
+	var ACL string
 
-	opts, hasOptions := f.fileSystem.options.(Options)
-	if hasOptions {
-		hasACLOption = opts.ACL != ""
-	}
+	fileOptions := f.Location().FileSystem().(*FileSystem).options
+	targetOptions := targetFile.Location().FileSystem().(*FileSystem).options
 
-	if hasOptions && targetFile.fileSystem.options != nil {
-		isSameAccount = opts.AccessKeyID == targetFile.fileSystem.options.(Options).AccessKeyID
+
+	if fileOptions == nil && targetOptions == nil {
+		// if both opts are nil, we must be using them default credentials
+		isSameAccount = true
+	} else {
+		opts, hasOptions := fileOptions.(Options)
+		targetOpts, hasTargetOptions := targetOptions.(Options)
+		if hasOptions {
+			//use source ACL (even if empty), unless target ACL is set
+			ACL = opts.ACL
+			if hasTargetOptions && targetOpts.ACL != "" {
+				ACL = targetOpts.ACL
+			}
+			if hasTargetOptions {
+				// since accesskey and session token are mutually exclusive, one will be nil
+				// if both are the same, we're using the same credentials
+				isSameAccount = (opts.AccessKeyID == targetOpts.AccessKeyID) && (opts.SessionToken == targetOpts.SessionToken)
+			}
+		}
 	}
 
 	// If both files use the same account, copy with native library. Otherwise, copy to disk
 	// first before pushing out to the target file's location.
-	copyInput := new(s3.CopyObjectInput).
-		SetKey(targetFile.key).
-		SetBucket(targetFile.bucket).
-		SetCopySource(path.Join(f.bucket, f.key))
-
-	if hasOptions && hasACLOption {
-		copyInput.SetACL(opts.ACL)
-	}
-
 	if isSameAccount {
-		client, err := f.fileSystem.Client()
+		//parse so we can use url.EscapedPath()in SetCopySource()
+		u, err := url.Parse(path.Join(f.bucket, f.key))
 		if err != nil {
-			return err
+			return nil, err
 		}
+		copyInput := new(s3.CopyObjectInput).
+			SetServerSideEncryption("AES256").
+			SetACL(ACL).
+			SetKey(targetFile.key).
+			SetBucket(targetFile.bucket).
+			SetCopySource(u.EscapedPath())
 
-		_, err = client.CopyObject(copyInput)
-
-		return err
+		return copyInput, copyInput.Validate()
 	}
 
-	if err := utils.TouchCopy(targetFile, f); err != nil {
-		return err
-	}
-
-	return nil
+	//return nil if credentials aren't the same
+	return nil, nil
 }
 
 func (f *File) checkTempFile() error {

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -211,23 +211,23 @@ func (ts *fileTestSuite) TestGetCopyObject() {
 	tests := []getCopyObjectTest{
 		{
 			key:                "/path/to/nospace.txt",
-			expectedCopySource: "/path/to/nospace.txt",
+			expectedCopySource: "%2Fpath%2Fto%2Fnospace.txt",
 		},
 		{
 			key:                "/path/to/has space.txt",
-			expectedCopySource: "/path/to/has%20space.txt",
+			expectedCopySource: "%2Fpath%2Fto%2Fhas%20space.txt",
 		},
 		{
 			key:                "/path/to/encoded%20space.txt",
-			expectedCopySource: "/path/to/encoded%2520space.txt",
+			expectedCopySource: "%2Fpath%2Fto%2Fencoded%2520space.txt",
 		},
 		{
 			key:                "/path/to/has space/file.txt",
-			expectedCopySource: "/path/to/has%20space/file.txt",
+			expectedCopySource: "%2Fpath%2Fto%2Fhas%20space%2Ffile.txt",
 		},
 		{
 			key:                "/path/to/encoded%20space/file.txt",
-			expectedCopySource: "/path/to/encoded%2520space/file.txt",
+			expectedCopySource: "%2Fpath%2Fto%2Fencoded%2520space%2Ffile.txt",
 		},
 	}
 

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -330,7 +330,7 @@ func (ts *fileTestSuite) TestMoveToLocation() {
 
 	// test non-scheme MoveToLocation
 	mockLocation := new(mocks.Location)
-	mockLocation.On("NewFile", mock.Anything).Return(&File{}, nil)
+	mockLocation.On("NewFile", mock.Anything).Return(&File{fileSystem: &FileSystem{client: s3Mock1}, bucket: "bucket", key: "/new/hello.txt"}, nil)
 
 	s3apiMock2 := &mocks.S3API{}
 	s3apiMock2.On("CopyObject", mock.AnythingOfType("*s3.CopyObjectInput")).Return(&s3.CopyObjectOutput{}, nil)
@@ -355,7 +355,7 @@ func (ts *fileTestSuite) TestMoveToLocationFail() {
 	// If CopyToLocation fails we need to ensure DeleteObject isn't called.
 	otherFs := new(mocks.FileSystem)
 	location := new(mocks.Location)
-	location.On("NewFile", mock.Anything).Return(&File{fileSystem: &fs}, nil)
+	location.On("NewFile", mock.Anything).Return(&File{fileSystem: &fs, bucket: "bucket", key: "/new/hello.txt"}, nil)
 
 	s3apiMock.On("CopyObject", mock.AnythingOfType("*s3.CopyObjectInput")).Return(nil, errors.New("didn't copy, oh noes"))
 	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -219,7 +219,7 @@ func (ts *fileTestSuite) TestGetCopyObject() {
 		},
 		{
 			key:                "/path/to/encoded%20space.txt",
-			expectedCopySource: "/path/to/encoded%20space.txt",
+			expectedCopySource: "/path/to/encoded%2520space.txt",
 		},
 		{
 			key:                "/path/to/has space/file.txt",
@@ -227,7 +227,7 @@ func (ts *fileTestSuite) TestGetCopyObject() {
 		},
 		{
 			key:                "/path/to/encoded%20space/file.txt",
-			expectedCopySource: "/path/to/encoded%20space/file.txt",
+			expectedCopySource: "/path/to/encoded%2520space/file.txt",
 		},
 	}
 


### PR DESCRIPTION
Ensure that spaces (url encoded or not) in filenames and paths work as expected when copying (particularly for s3 to s3 native copyObject).  Fixes #36 