### PR TITLE
Fixed issue related to https://github.com/pkg/sftp/pull/310/files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.3] - 2020-05-11
+### Fixed
+- Addresses an issue where writes/touch calls on the vfs.File backend did not work properly on AWS-hosted SFTP environments. (See https://github.com/pkg/sftp/pull/310/files)
+
 ## [5.5.2] - 2020-04-23
 ### Fixed
 - Ensure that writing truncates existing file. Fixes #40

--- a/backend/sftp/file.go
+++ b/backend/sftp/file.go
@@ -76,7 +76,7 @@ func (f *File) Touch() error {
 	}
 
 	if !exists {
-		file, err := f.openFile(os.O_RDWR | os.O_CREATE)
+		file, err := f.openFile(os.O_WRONLY | os.O_CREATE)
 		if err != nil {
 			return err
 		}
@@ -252,7 +252,7 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 // Write calls the underlying sftp.File Write.
 func (f *File) Write(data []byte) (res int, err error) {
 
-	sftpfile, err := f.openFile(os.O_RDWR | os.O_CREATE)
+	sftpfile, err := f.openFile(os.O_WRONLY | os.O_CREATE)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
While attempting to connect to an SFTP server hosted on Amazon AWS, the following error is thrown:

> Cannot open file in mode: WRITE|CREATE|READ" (SSH_FX_OP_UNSUPPORTED)

This is related to https://github.com/pkg/sftp/issues/305