### PR TITLE
fix tests from last bugfix in e341191 where HeadObject is no long exp…

### DIFF
--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -180,7 +180,6 @@ func (f *File) Delete() error {
 // Close cleans up underlying mechanisms for reading from and writing to the file. Closes and removes the
 // local temp file, and triggers a write to s3 of anything in the f.writeBuffer if it has been created.
 func (f *File) Close() error {
-
 	if f.tempFile != nil {
 		err := f.tempFile.Close()
 		if err != nil {
@@ -258,7 +257,6 @@ func (f *File) Write(data []byte) (res int, err error) {
 // Touch creates a zero-length file on the vfs.File if no File exists.  Update File's last modified timestamp.
 // Returns error if unable to touch File.
 func (f *File) Touch() error {
-
 	//check if file exists
 	exists, err := f.Exists()
 	if err != nil {

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -53,7 +53,6 @@ func (ts *fileTestSuite) TestRead() {
 	s3apiMock.On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).Return(&s3.GetObjectOutput{
 		Body: nopCloser{bytes.NewBufferString(contents)},
 	}, nil)
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 
 	file, err := fs.NewFile("bucket", "/some/path/file.txt")
 	if err != nil {
@@ -91,7 +90,6 @@ func (ts *fileTestSuite) TestSeek() {
 	s3apiMock.On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).Return(&s3.GetObjectOutput{
 		Body: nopCloser{bytes.NewBufferString(contents)},
 	}, nil)
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 
 	_, seekErr := file.Seek(6, 0)
 	assert.NoError(ts.T(), seekErr, "no error expected")
@@ -197,7 +195,6 @@ func (ts *fileTestSuite) TestMoveToFile() {
 
 	s3apiMock.On("CopyObject", mock.AnythingOfType("*s3.CopyObjectInput")).Return(&s3.CopyObjectOutput{}, nil)
 	s3apiMock.On("DeleteObject", mock.AnythingOfType("*s3.DeleteObjectInput")).Return(&s3.DeleteObjectOutput{}, nil)
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 
 	err := testFile.MoveToFile(targetFile)
 	ts.Nil(err, "Error shouldn't be returned from successful call to CopyToFile")
@@ -395,7 +392,6 @@ func (ts *fileTestSuite) TestMoveToLocation() {
 
 	s3apiMock.On("CopyObject", mock.AnythingOfType("*s3.CopyObjectInput")).Return(&s3.CopyObjectOutput{}, nil)
 	s3apiMock.On("DeleteObject", mock.AnythingOfType("*s3.DeleteObjectInput")).Return(&s3.DeleteObjectOutput{}, nil)
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 
 	file, err := fs.NewFile("bucket", "/hello.txt")
 	if err != nil {
@@ -416,8 +412,6 @@ func (ts *fileTestSuite) TestMoveToLocation() {
 
 	s3apiMock2 := &mocks.S3API{}
 	s3apiMock2.On("CopyObject", mock.AnythingOfType("*s3.CopyObjectInput")).Return(&s3.CopyObjectOutput{}, nil)
-	val := int64(0)
-	s3apiMock2.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{ContentLength: &val}, nil)
 
 	fs = FileSystem{client: s3apiMock2}
 	file2, err := fs.NewFile("bucket", "/hello.txt")
@@ -440,7 +434,6 @@ func (ts *fileTestSuite) TestMoveToLocationFail() {
 	location.On("NewFile", mock.Anything).Return(&File{fileSystem: &fs, bucket: "bucket", key: "/new/hello.txt"}, nil)
 
 	s3apiMock.On("CopyObject", mock.AnythingOfType("*s3.CopyObjectInput")).Return(nil, errors.New("didn't copy, oh noes"))
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 
 	file, err := fs.NewFile("bucket", "/hello.txt")
 	if err != nil {
@@ -461,7 +454,6 @@ func (ts *fileTestSuite) TestMoveToLocationFail() {
 
 func (ts *fileTestSuite) TestDelete() {
 	s3apiMock.On("DeleteObject", mock.AnythingOfType("*s3.DeleteObjectInput")).Return(&s3.DeleteObjectOutput{}, nil)
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 	err := testFile.Delete()
 	ts.Nil(err, "Successful delete should not return an error.")
 	s3apiMock.AssertExpectations(ts.T())

--- a/backend/s3/location_test.go
+++ b/backend/s3/location_test.go
@@ -292,7 +292,6 @@ func (lt *locationTestSuite) TestStringURI() {
 }
 
 func (lt *locationTestSuite) TestDeleteFile() {
-	lt.s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{}, nil)
 	lt.s3apiMock.On("DeleteObject", mock.AnythingOfType("*s3.DeleteObjectInput")).Return(&s3.DeleteObjectOutput{}, nil)
 	loc, err := lt.fs.NewLocation("bucket", "/old/")
 	lt.NoError(err)


### PR DESCRIPTION
…ected because most tests no longer hit waitUntilFileExists() in file.Close()