### PR TITLE
Fix: do not offset number of bytes read for memfs

### DIFF
--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -93,7 +93,6 @@ func (f *File) Read(p []byte) (n int, err error) {
 		return 0, doesNotExist()
 	}
 	// if file exists:
-	offset := f.cursor
 	if !f.isOpen {
 		f.isOpen = true
 	}
@@ -130,7 +129,7 @@ func (f *File) Read(p []byte) (n int, err error) {
 	if f.cursor > len(f.contents) {
 		f.cursor = len(f.contents)
 	}
-	return readBufferLength - offset, nil
+	return readBufferLength, nil
 
 }
 


### PR DESCRIPTION
Previously memfs backend's Read would correctly assign the data read
from a file when its cursor position was not at 0, but the returned n
int was incorrectly offset by the original cursor position.

Add a test for successive reads on memfs file.

--------------
Hi there, we recently started with your project and noticed this bug when testing partial file reads using memfs.
I have included the fix and a new test case to cover it. Please do feel free to let me know if there's anything I have missed, definitely happy to take suggestions as this is my first contribution to the project. Thanks!