### PR TITLE
Removed need to call Size() in TouchCopy. Also reduced signature to o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Fixed
+- fixed #71 Listing a Google Cloud Storage bucket does not return things in the root of the bucket
+### Performance
+- fixed #74 utils.TouchCopy() unnecessarily calls file.Size()
 
 ## [5.5.7] - 2021-05-12
 ### Fixed

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -173,8 +175,9 @@ func (ts *fileTestSuite) TestEmptyCopyToFile() {
 	targetFile.On("Write", mock.Anything).Return(0, nil)
 	targetFile.On("Close").Return(nil)
 
-	expectedSize := int64(0)
-	s3apiMock.On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).Return(&s3.HeadObjectOutput{ContentLength: &expectedSize}, nil, nil)
+	// TODO: note that ioutils.NopCloser is deprecated with 1.16 and will be moved to io.NopCloser
+	rc := ioutil.NopCloser(strings.NewReader(""))
+	s3apiMock.On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).Return(&s3.GetObjectOutput{Body: rc}, nil, nil)
 
 	err := testFile.CopyToFile(targetFile)
 	ts.Nil(err, "Error shouldn't be returned from successful call to CopyToFile")

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -69,7 +69,7 @@ RemoveTrailingSlash removes trailing slash, if any
 #### func  TouchCopy
  
 ```go
-func TouchCopy(writer, reader vfs.File) error
+func TouchCopy(writer io.Writer, reader io.Reader) error
 ```
 TouchCopy is a wrapper around [io.Copy](https://godoc.org/io#Copy) which ensures that even empty source files
 (reader) will get written as an empty file. It guarantees a Write() call on the target file.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -98,16 +98,16 @@ func EnsureLeadingSlash(dir string) string {
 
 // TouchCopy is a wrapper around io.Copy which ensures that even empty source files (reader) will get written as an
 // empty file. It guarantees a Write() call on the target file.
-func TouchCopy(writer, reader vfs.File) error {
-	if size, err := reader.Size(); err != nil {
+func TouchCopy(writer io.Writer, reader io.Reader) error {
+	size, err := io.Copy(writer, reader)
+	if err != nil {
 		return err
-	} else if size == 0 {
+	}
+	if size == 0 {
 		_, err = writer.Write([]byte{})
 		if err != nil {
 			return err
 		}
-	} else if _, err := io.Copy(writer, reader); err != nil {
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
…nly need io.Reader and io.Writer, rather than vfs.File.

fixes #74