### PR TITLE
Allow commandline to specify multiple kex algos

### DIFF
--- a/backend/sftp/options.go
+++ b/backend/sftp/options.go
@@ -26,7 +26,7 @@ type Options struct {
 	KeyPassphrase      string              `json:"keyPassphrase,omitempty"`  // env var VFS_SFTP_KEYFILE_PASSPHRASE
 	KnownHostsFile     string              `json:"knownHostsFile,omitempty"` // env var VFS_SFTP_KNOWN_HOSTS_FILE
 	KnownHostsString   string              `json:"knownHostsString,omitempty"`
-	KeyExchanges       string              `json:"keyExchanges,omitempty"`
+	KeyExchanges       []string            `json:"keyExchanges,omitempty"`
 	AutoDisconnect     int                 `json:"autoDisconnect,omitempty"` // seconds before disconnecting. default: 10
 	KnownHostsCallback ssh.HostKeyCallback // env var VFS_SFTP_INSECURE_KNOWN_HOSTS
 	Retry              vfs.Retry
@@ -56,9 +56,9 @@ func getClient(authority utils.Authority, opts Options) (Client, error) {
 	// server offered: [diffie-hellman-group-exchange-sha256 ]
 	// Now receive KeyExchange algorithm as an option
 	sshConfig := ssh.Config{}
-	if opts.KeyExchanges != "" {
+	if len(opts.KeyExchanges) != 0 {
 		sshConfig = ssh.Config{
-			KeyExchanges: []string{opts.KeyExchanges},
+			KeyExchanges: opts.KeyExchanges,
 		}
 	}
 	// Define the Client Config

--- a/backend/sftp/options_test.go
+++ b/backend/sftp/options_test.go
@@ -338,7 +338,7 @@ func (o *optionsSuite) TestGetAuthMethods() {
 				KeyFilePath:   o.keyFiles.SSHPrivateKey,
 				KeyPassphrase: o.keyFiles.passphrase,
 				Password:      "somepassword",
-				KeyExchanges:  "diffie-hellman-group-exchange-sha256",
+				KeyExchanges:  []string{"diffie-hellman-group-exchange-sha256"},
 			},
 			returnCount: 2,
 			hasError:    false,

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -154,6 +154,11 @@ testing but should not be used in production.
 
 ### Other Options
 
+Passing in multiple key exchange algorithms is supported - these are specified as a slice.
+```
+'{"keyFilePath":"hsbc_uat_rsa", "keyExchanges":["diffie-hellman-group-a256"]}'
+```
+
 #### AutoDisconnect
 When dialing an TCP connection, go doesn't disconnect for you, even when the connection fall out of scope (or even when
 garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
@@ -569,7 +574,7 @@ type Options struct {
 	KeyPassphrase      string              `json:"keyPassphrase,omitempty"`  // env var VFS_SFTP_KEYFILE_PASSPHRASE
 	KnownHostsFile     string              `json:"knownHostsFile,omitempty"` // env var VFS_SFTP_KNOWN_HOSTS_FILE
 	KnownHostsString   string              `json:"knownHostsString,omitempty"`
-	KeyExchanges       string              `json:"keyExchanges,omitempty"`
+	KeyExchanges       []string            `json:"keyExchanges,omitempty"`
 	KnownHostsCallback ssh.HostKeyCallback //env var VFS_SFTP_INSECURE_KNOWN_HOSTS
 	Retry              vfs.Retry
 	MaxRetries         int


### PR DESCRIPTION
## Description

In the sftp vfs backend, the option KeyExchanges currently only allows one kex algorithm.  Internally, the ssh.Config KeyExchanges key expects an array of kex algos. Even though we use a plural name "KeyExchanges", we only allow one key exchange.

As a user, I would generally like to provide more than one kex algo, if I provide any at all (instead of using the default set).

We should accept an array of exchanges.

We should update the docs/sftp.md 's `Other Options` section to include KeyExchanges usage.