### PR TITLE
Fix autodisconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Fixed
+- fixed #103 Ensures that sftp backend closed underlying SSH connection on autodisconnect, not just SFTP subsystem.
 
 ## [6.0.0] - 2021-09-29
 ### Changed

--- a/backend/sftp/doc.go
+++ b/backend/sftp/doc.go
@@ -133,5 +133,48 @@ Passing in multiple key exchange algorithms is supported - these are specified a
 Example:
 `"keyExchanges":["diffie-hellman-group-a256", "ecdh-sha2-nistp256"]`
 
+AutoDisconnect
+
+When dialing an TCP connection, go doesn't disconnect for you, even when the connection falls out of scope (or even when
+garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
+Instead, the sftp backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is
+cancelled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
+If the timer is not interrupted by any request, it will disconnect from the server.  Any subsequent server request will
+first reconnect, the do the action.  This timer can be overridden with any number of second (zero is an immediate disconnect).
+
+Options.AutoDisconnect accepts an integer representing the number seconds before disconnecting after being idle.
+Default value is 10 seconds.
+
+Any server request action using the same underlying FileSystem (and therefore sftp client), will reset the timer.  This
+should be the most desirable behavior.
+
+	func doSFTPStuff() {
+		fs := sftp.NewFilesystem()
+		loc, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
+		file1, _ := loc.NewFile("file1.txt")
+		file2, _ := loc.NewFile("file2.txt")
+		file1.Touch()                               // "touches" file and starts disconnect timer (default: 10sec)
+		_, _ := loc.List()                          // stops timer, does location listing, resets timer to 10 seconds
+		file2.Touch()                               // stops timer, "touches" file2, resets timer to 10 seconds
+		time.Sleep(time.Duration(15) * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
+		_, _ := loc.List()                          // does location listing, starts new disconnect timer
+		return
+	}
+
+	func main {
+		// call our sftp function
+		doSFTPStuff()
+		// even though the vfs sftp objects have fallen out of scope, our connection remains UNTIL the timer counts down
+
+		// do more work (that take longer than 10 seconds
+		doOtherTimeConsumingStuff()
+
+		// at some point during the above, the sftp connection will have closed
+	}
+
+NOTE: AutoDisconnect has nothing to do with "keep alive".  Here we're only concerned with releasing resources, not keeping
+the server from disconnecting us.  If that is something you want, you'd have to implement yourself, injecting your own
+client using WithClient().
+
 */
 package sftp

--- a/backend/sftp/doc.go
+++ b/backend/sftp/doc.go
@@ -135,12 +135,13 @@ Example:
 
 AutoDisconnect
 
-When dialing an TCP connection, go doesn't disconnect for you, even when the connection falls out of scope (or even when
-garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
-Instead, the sftp backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is
-canceled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
-If the timer is not interrupted by any request, it will disconnect from the server.  Any subsequent server request will
-first reconnect, the do the action.  This timer can be overridden with any number of second (zero is an immediate disconnect).
+When dialing a TCP connection, Go doesn't disconnect for you.  This is true even when the connection falls out of scope, and even when
+garbage collection is forced.  The connection must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
+
+Instead, the SFTP backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is
+canceled anytime a server-side request (like list, read, etc) is made.  Once the request has completed, a new timer will begin.
+If the timer expires (because it is not interrupted by any request), the server connection will be closed.  Any subsequent server
+request will first reconnect, perform the request, and start a new disconnect timer.
 
 Options.AutoDisconnect accepts an integer representing the number seconds before disconnecting after being idle.
 Default value is 10 seconds.
@@ -157,7 +158,7 @@ should be the most desirable behavior.
 		_, _ := loc.List()                          // stops timer, does location listing, resets timer to 10 seconds
 		file2.Touch()                               // stops timer, "touches" file2, resets timer to 10 seconds
 		time.Sleep(time.Duration(15) * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
-		_, _ := loc.List()                          // does location listing, starts new disconnect timer
+		_, _ := loc.List()                          // reconnects, does location listing, starts new disconnect timer
 		return
 	}
 

--- a/backend/sftp/doc.go
+++ b/backend/sftp/doc.go
@@ -138,7 +138,7 @@ AutoDisconnect
 When dialing an TCP connection, go doesn't disconnect for you, even when the connection falls out of scope (or even when
 garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
 Instead, the sftp backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is
-cancelled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
+canceled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
 If the timer is not interrupted by any request, it will disconnect from the server.  Any subsequent server request will
 first reconnect, the do the action.  This timer can be overridden with any number of second (zero is an immediate disconnect).
 

--- a/backend/sftp/fileSystem_test.go
+++ b/backend/sftp/fileSystem_test.go
@@ -1,6 +1,7 @@
 package sftp
 
 import (
+	"io"
 	"os"
 	"regexp"
 	"testing"
@@ -138,9 +139,9 @@ func (ts *fileSystemTestSuite) TestClientWithAutoDisconnect() {
 	client := &mocks.Client{}
 	client.On("ReadDir", "/").Return([]os.FileInfo{}, nil).Times(3)
 	client.On("Close").Return(nil).Times(1)
-	defaultClientGetter = func(utils.Authority, Options) (Client, error) {
+	defaultClientGetter = func(utils.Authority, Options) (Client, io.Closer, error) {
 		getClientCount++
-		return client, nil
+		return client, nil, nil
 	}
 
 	// setup location with auto-disconnect of one second

--- a/backend/sftp/options.go
+++ b/backend/sftp/options.go
@@ -77,7 +77,7 @@ func getClient(authority utils.Authority, opts Options) (Client, io.Closer, erro
 		return nil, nil, err
 	}
 
-	sftpClient, err :=  _sftp.NewClient(sshConn)
+	sftpClient, err := _sftp.NewClient(sshConn)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/sftp/options_test.go
+++ b/backend/sftp/options_test.go
@@ -444,7 +444,7 @@ func (o *optionsSuite) TestGetClient() {
 
 	for _, t := range tests { // nolint:gocritic // rangeValCopy
 		// apply test
-		_, err := getClient(t.authority, t.options)
+		_, _, err := getClient(t.authority, t.options)
 		if t.hasError {
 			if o.Error(err, "error found") {
 				re := regexp.MustCompile(t.errRegex)

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -161,12 +161,13 @@ Passing in multiple key exchange algorithms is supported - these are specified a
 
 ### AutoDisconnect
 
-When dialing an TCP connection, go doesn't disconnect for you, even when the connection falls out of scope (or even when
-garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
-Instead, the sftp backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is 
-canceled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
-If the timer is not interrupted by any request, it will disconnect from the server.  Any subsequent server request will
-first reconnect, the do the action.  This timer can be overridden with any number of second (zero is an immediate disconnect).
+When dialing a TCP connection, Go doesn't disconnect for you.  This is true even when the connection falls out of scope, and even when
+garbage collection is forced.  The connection must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
+
+Instead, the SFTP backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is
+canceled anytime a server-side request (like list, read, etc) is made.  Once the request has completed, a new timer will begin.
+If the timer expires (because it is not interrupted by any request), the server connection will be closed.  Any subsequent server
+request will first reconnect, perform the request, and start a new disconnect timer.
 
 [Options](#type-options).AutoDisconnect accepts an integer representing the number seconds before disconnecting after being idle.
 Default value is 10 seconds.
@@ -184,7 +185,7 @@ func doSFTPStuff() {
     _, _ := loc.List()                          // stops timer, does location listing, resets timer to 10 seconds
     file2.Touch()                               // stops timer, "touches" file2, resets timer to 10 seconds
     time.Sleep(time.Duration(15) * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
-    _, _ := loc.List()                          // does location listing, starts new disconnect timer
+    _, _ := loc.List()                          // reconnects, does location listing, starts new disconnect timer
     return
 }
 

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -164,7 +164,7 @@ Passing in multiple key exchange algorithms is supported - these are specified a
 When dialing an TCP connection, go doesn't disconnect for you, even when the connection falls out of scope (or even when
 garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
 Instead, the sftp backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is 
-cancelled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
+canceled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
 If the timer is not interrupted by any request, it will disconnect from the server.  Any subsequent server request will
 first reconnect, the do the action.  This timer can be overridden with any number of second (zero is an immediate disconnect).
 

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -159,18 +159,19 @@ Passing in multiple key exchange algorithms is supported - these are specified a
 "keyExchanges":["diffie-hellman-group-a256", "ecdh-sha2-nistp256"]
 ```
 
-#### AutoDisconnect
-When dialing an TCP connection, go doesn't disconnect for you, even when the connection fall out of scope (or even when
+### AutoDisconnect
+
+When dialing an TCP connection, go doesn't disconnect for you, even when the connection falls out of scope (or even when
 garbage collection is forced).  It must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
 Instead, the sftp backend will automatically disconnect 10 seconds (default) after connection.  This disconnect timer is 
-paused anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
+cancelled anytime a server-side request (like list, read, etc) is made.  Once the action is complete, a new timer will begin.
 If the timer is not interrupted by any request, it will disconnect from the server.  Any subsequent server request will
 first reconnect, the do the action.  This timer can be overridden with any number of second (zero is an immediate disconnect).
 
 [Options](#type-options).AutoDisconnect accepts an integer representing the number seconds before disconnecting after being idle.
 Default value is 10 seconds.
 
-Any server request action using the same underlying FileSystem (and therefore sftp client), will reset the time.  This
+Any server request action using the same underlying FileSystem (and therefore sftp client), will reset the timer.  This
 should be the most desirable behavior.
 
 ```go
@@ -201,7 +202,7 @@ func main {
 
 NOTE: AutoDisconnect has nothing to do with "keep alive".  Here we're only concerned with releasing resources, not keeping
 the server from disconnecting us.  If that is something you want, you'd have to implement yourself, injecting your own 
-client using WithClient(). 
+client using WithClient().
 
 ## Usage
 


### PR DESCRIPTION
fixes #103 

Ensures that sftp backend closed underlying SSH connection on autodisconnect, not just SFTP subsystem:
* Stores underlying ssh conn on the struct as an io.Closer.  
* Call Close when auto-disconnect timeout is triggered.