### PR TITLE
Fix vfssimple factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fixed linting issues with missing godoc on exported functions and new build tag formatting.
 - fixed #92 (broken by #72) where calling ListByPrefix() was fail from non-root locations when calling file-level prefixes.
+- ensure azure helper func for vfssimple works on File URIs in addition to Location URIs
+- fixed #97 by updating vfssimple logic to ensure the most specific registered backend that matches a url is used, not just the first one it comes across.  Updated vfssimple docs.
 
 ## [6.0.1] - 2021-11-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fixed linting issues with missing godoc on exported functions and new build tag formatting.
 - fixed #92 (broken by #72) where calling ListByPrefix() was fail from non-root locations when calling file-level prefixes.
-- ensure azure helper func for vfssimple works on File URIs in addition to Location URIs
 - fixed azure helper func for vfssimple, ensuring it works on File URIs in addition to Location URIs
 - fixed #97 by updating vfssimple logic to ensure the most specific registered backend that matches a url is used, not just the first one it comes across.  Updated vfssimple docs.
 - Added vfssimple tests.  Zero to 100% coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed linting issues with missing godoc on exported functions and new build tag formatting.
 - fixed #92 (broken by #72) where calling ListByPrefix() was fail from non-root locations when calling file-level prefixes.
 - ensure azure helper func for vfssimple works on File URIs in addition to Location URIs
+- fixed azure helper func for vfssimple, ensuring it works on File URIs in addition to Location URIs
 - fixed #97 by updating vfssimple logic to ensure the most specific registered backend that matches a url is used, not just the first one it comes across.  Updated vfssimple docs.
+- Added vfssimple tests.  Zero to 100% coverage.
 
 ## [6.0.1] - 2021-11-07
 ### Fixed

--- a/backend/azure/fileSystem.go
+++ b/backend/azure/fileSystem.go
@@ -127,14 +127,22 @@ func init() {
 	backend.Register(Scheme, NewFileSystem())
 }
 
-// ParsePath is a utility function used by vfssiple to separate the host from the path.  The first parameter returned
+// ParsePath is a utility function used by vfssimple to separate the host from the path.  The first parameter returned
 // is the host and the second parameter is the path.
 func ParsePath(p string) (host, pth string, err error) {
 	if p == "/" {
 		return "", "", errors.New("no container specified for Azure path")
 	}
+	var isLocation bool
+	if p[len(p)-1:] == string(os.PathSeparator) {
+		isLocation = true
+	}
 	l := strings.Split(p, string(os.PathSeparator))
-	return l[1], utils.EnsureTrailingSlash(utils.EnsureLeadingSlash(path.Join(l[2:]...))), nil
+	p = utils.EnsureLeadingSlash(path.Join(l[2:]...))
+	if isLocation {
+		p = utils.EnsureTrailingSlash(p)
+	}
+	return l[1], p, nil
 }
 
 // IsValidURI us a utility function used by vfssimple to determine if the given URI is a valid Azure URI

--- a/backend/azure/fileSystem_test.go
+++ b/backend/azure/fileSystem_test.go
@@ -189,6 +189,13 @@ func (s *FileSystemTestSuite) TestParsePath() {
 	s.Error(err, "a container is required so we should get an error")
 	s.Equal("", volume, "we got an error so volume should be empty")
 	s.Equal("", path, "we got an error so path should be empty")
+
+	uri = "https://my-account.blob.core.windows.net/my_container/foo/bar/baz.txt"
+	u, _ = url.Parse(uri)
+	volume, path, err = ParsePath(u.Path)
+	s.NoError(err, "File Path is valid so we should not get an error")
+	s.Equal("my_container", volume)
+	s.Equal("/foo/bar/baz.txt", path)
 }
 
 func (s *FileSystemTestSuite) TestIsValidURI() {

--- a/docs/vfssimple.md
+++ b/docs/vfssimple.md
@@ -26,18 +26,18 @@ Just import vfssimple.
 	func main() {
 		myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
 		if err != nil {
-            panic(err)
-        }
+			panic(err)
+		}
 
 		myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
 		if err != nil {
-            panic(err)
-        }
+			panic(err)
+		}
 
 		localFile, err := myS3File.MoveToLocation(myLocalDir)
 		if err != nil {
-            panic(err)
-        }
+			panic(err)
+		}
 
 		fmt.Printf("moved %s to %s\n", myS3File, localFile)
 	}

--- a/docs/vfssimple.md
+++ b/docs/vfssimple.md
@@ -15,32 +15,32 @@ supported backend file system by using full URI's:
 Just import vfssimple.
 
 ```go
-    package main
-    
-    import (
-        "fmt"
-    
-        "github.com/c2fo/vfs/v6/vfssimple"
-    )
-    
-    func main() {
-        myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
-        if err != nil {
+	package main
+
+	import (
+		"fmt"
+
+		"github.com/c2fo/vfs/v6/vfssimple"
+	)
+
+	func main() {
+		myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
+		if err != nil {
             panic(err)
         }
-    
-        myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
-        if err != nil {
+
+		myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
+		if err != nil {
             panic(err)
         }
-    
-        localFile, err := myS3File.MoveToLocation(myLocalDir)
-        if err != nil {
+
+		localFile, err := myS3File.MoveToLocation(myLocalDir)
+		if err != nil {
             panic(err)
         }
-    
-        fmt.Printf("moved %s to %s\n", myS3File, localFile)
-    }
+
+		fmt.Printf("moved %s to %s\n", myS3File, localFile)
+	}
 ```
 
 ### Authentication and Options
@@ -56,37 +56,37 @@ resolve the provided URI in NewFile() or NewLocation() to the registered file sy
 ```go
 	package main
 
-    import(
+	import(
 		"fmt"
 
-        "github.com/c2fo/vfs/v6/backend"
-        "github.com/c2fo/vfs/v6/backend/s3"
-        "github.com/c2fo/vfs/v6/vfssimple"
-    )
-    
-    func main() {
-        bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
-            AccessKeyID:     "key1",
-            SecretAccessKey: "secret1",
-            Region:          "us-west-2",
-        })
-    
-        fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
-            AccessKeyID:     "key2",
-            SecretAccessKey: "secret2",
-            Region:          "us-west-2",
-        })
-    
-        backend.Register("s3://bucket1/", bucketAuth)
-        backend.Register("s3://bucket2/file.txt", fileAuth)
-    
-        secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
-        publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
-    
-        secureFile.CopyToLocation(publicLocation)
+		"github.com/c2fo/vfs/v6/backend"
+		"github.com/c2fo/vfs/v6/backend/s3"
+		"github.com/c2fo/vfs/v6/vfssimple"
+	)
+
+	func main() {
+		bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
+			AccessKeyID:     "key1",
+			SecretAccessKey: "secret1",
+			Region:          "us-west-2",
+		})
+
+		fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
+			AccessKeyID:     "key2",
+			SecretAccessKey: "secret2",
+			Region:          "us-west-2",
+		})
+
+		backend.Register("s3://bucket1/", bucketAuth)
+		backend.Register("s3://bucket2/file.txt", fileAuth)
+
+		secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
+		publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
+
+		secureFile.CopyToLocation(publicLocation)
 
 		fmt.Printf("copied %s to %s\n", secureFile, publicLocation)
-    }
+	}
 ```
 
 ### Registered Backend Resolution

--- a/docs/vfssimple.md
+++ b/docs/vfssimple.md
@@ -17,27 +17,29 @@ Just import vfssimple.
 ```go
     package main
     
-    import(
+    import (
+        "fmt"
+    
         "github.com/c2fo/vfs/v6/vfssimple"
     )
-
-    ...
-
-    func DoSomething() error {
+    
+    func main() {
         myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
         if err != nil {
-            return err
+            panic(err)
         }
-        
+    
         myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
         if err != nil {
-            return err
+            panic(err)
         }
-        
+    
         localFile, err := myS3File.MoveToLocation(myLocalDir)
         if err != nil {
-            return err
+            panic(err)
         }
+    
+        fmt.Printf("moved %s to %s\n", myS3File, localFile)
     }
 ```
 
@@ -52,37 +54,74 @@ you can register and map file system options to locations or individual objects.
 resolve the provided URI in NewFile() or NewLocation() to the registered file system.
 
 ```go
-    package main
-    
+	package main
+
     import(
-        "github.com/c2fo/vfs/v6/vfssimple"
+		"fmt"
+
         "github.com/c2fo/vfs/v6/backend"
         "github.com/c2fo/vfs/v6/backend/s3"
+        "github.com/c2fo/vfs/v6/vfssimple"
     )
     
-    ...
-    
-    func DoSomething() error {
+    func main() {
         bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
             AccessKeyID:     "key1",
-            SecretAccessKey: "secret1,
+            SecretAccessKey: "secret1",
             Region:          "us-west-2",
         })
-        
+    
         fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
             AccessKeyID:     "key2",
-            SecretAccessKey: "secret2,
+            SecretAccessKey: "secret2",
             Region:          "us-west-2",
         })
-        
-        backend.Register("s3://bucket1/, bucketAuth)
-        backend.Register("s3://bucket2/file.txt, fileAuth)
-        
+    
+        backend.Register("s3://bucket1/", bucketAuth)
+        backend.Register("s3://bucket2/file.txt", fileAuth)
+    
         secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
         publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
-        
+    
         secureFile.CopyToLocation(publicLocation)
+
+		fmt.Printf("copied %s to %s\n", secureFile, publicLocation)
     }
+```
+
+### Registered Backend Resolution
+
+Every backend type automatically registers itself as an available backend filesystem for vfssimple based on its scheme.  In this way,
+vfssimple is able to determine which backend to use for any related URI.  As mentioned above, you can register your own initialized
+filesystem as well.
+
+vfssimple resolves backends by doing a prefix match of the URI to the registered backend names, choosing the longest(most specific) matching
+backend filesystem.
+
+For instance, given registered backends with the names:
+
+```
+	's3'                         - registered by default
+	's3://somebucket/'           - perhaps this was registered using AWS access key id x
+	's3://somebucket/path/'      - and this was registered using AWS access key id y
+	's3://somebucket/path/a.txt' - and this was registered using AWS access key id z
+	's3://some'                  - another contrived registered fs for bucket
+```
+
+See the expected registered bucket name for each:
+
+```
+	's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt'         (most specific match)
+	's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt.tar.gz'  (prefix still matches)
+	's3://somebucket/path/'      - URI: 's3://somebucket/path/otherfile.txt' (file only matches path-level registered fs)
+	's3"//somebucket/path/'      - URI: 's3://somebucket/path/'              (exact path-level match)
+	's3://somebucket/'           - URI: 's3://somebucket/test/file.txt'      (bucket-level match only)
+	's3://somebucket/'           - URI: 's3://somebucket/test/'              (still bucket-level match only)
+	's3://somebucket/'           - URI: 's3://somebucket/'                   (exact bucket-level match)
+	's3://some'                  - URI: 's3://some-other-bucket/'            (bucket-level match)
+	's3'                         - URI: 's3://other/'                        (scheme-level match, only)
+	's3'                         - URI: 's3://other/file.txt'                (scheme-level match, only)
+	's3'                         - URI: 's3://other/path/to/nowhere/'        (scheme-level match, only)
 ```
 
 ### Retry Option

--- a/vfssimple/doc.go
+++ b/vfssimple/doc.go
@@ -8,31 +8,32 @@ Usage
 
 Just import vfssimple.
 
-  package main
+	package main
 
-  import(
-	"github.com/c2fo/vfs/v6/vfssimple"
-  )
+	import (
+		"fmt"
 
-  ...
+		"github.com/c2fo/vfs/v6/vfssimple"
+	)
 
-  func DoSomething() error {
-    myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
-    if err != nil {
-        return err
-    }
+	func main() {
+		myLocalDir, err := vfssimple.NewLocation("file:///tmp/")
+		if err != nil {
+			panic(err)
+		}
 
-    myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
-    if err != nil {
-        return err
-    }
+		myS3File, err := vfssimple.NewFile("s3://mybucket/some/path/to/key.txt")
+		if err != nil {
+			panic(err)
+		}
 
-    localFile, err := myS3File.MoveToLocation(myLocalDir)
-    if err != nil {
-        return err
-    }
+		localFile, err := myS3File.MoveToLocation(myLocalDir)
+		if err != nil {
+			panic(err)
+		}
 
-  }
+		fmt.Printf("moved %s to %s\n", myS3File, localFile)
+	}
 
 Authentication and Options
 
@@ -45,37 +46,70 @@ type/schema with separate credentials, you can register and map file system opti
 The vfssimple library will automatically try to resolve the provided URI in NewFile() or NewLocation() to the registered
 file system.
 
-  package main
+	package main
 
-  import(
-	"github.com/c2fo/vfs/v6/vfssimple"
-	"github.com/c2fo/vfs/v6/backend"
-	"github.com/c2fo/vfs/v6/backend/s3"
-  )
+    import(
+		"fmt"
 
-  ...
+        "github.com/c2fo/vfs/v6/backend"
+        "github.com/c2fo/vfs/v6/backend/s3"
+        "github.com/c2fo/vfs/v6/vfssimple"
+    )
 
-  func DoSomething() error {
-	bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
-		AccessKeyID:     "key1",
-		SecretAccessKey: "secret1,
-		Region:          "us-west-2",
-	})
+    func main() {
+        bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
+            AccessKeyID:     "key1",
+            SecretAccessKey: "secret1",
+            Region:          "us-west-2",
+        })
 
-	fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
-		AccessKeyID:     "key2",
-		SecretAccessKey: "secret2,
-		Region:          "us-west-2",
-	})
+        fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
+            AccessKeyID:     "key2",
+            SecretAccessKey: "secret2",
+            Region:          "us-west-2",
+        })
 
-	backend.Register("s3://bucket1/, bucketAuth)
-	backend.Register("s3://bucket2/file.txt, fileAuth)
+        backend.Register("s3://bucket1/", bucketAuth)
+        backend.Register("s3://bucket2/file.txt", fileAuth)
 
-	secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
-	publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
+        secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
+        publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
 
-	secureFile.CopyToLocation(publicLocation)
-  }
+        secureFile.CopyToLocation(publicLocation)
+
+		fmt.Printf("copied %s to %s\n", secureFile, publicLocation)
+    }
+
+Registered Backend Resolution
+
+Every backend type automatically registers itself as an available backend filesystem for vfssimple based on its scheme.  In this way,
+vfssimple is able to determine which backend to use for any related URI.  As mentioned above, you can register your own initialized
+filesystem as well.
+
+vfssimple resolves backends by doing a prefix match of the URI to the registered backend names, choosing the longest(most specific) matching
+backend filesystem.
+
+For instance, given registered backends with the names:
+
+	's3'                         - registered by default
+	's3://somebucket/'           - perhaps this was registered using AWS access key id x
+	's3://somebucket/path/'      - and this was registered using AWS access key id y
+	's3://somebucket/path/a.txt' - and this was registered using AWS access key id z
+	's3://some'                  - another contrived registered fs for bucket
+
+See the expected registered bucket name for each:
+
+	's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt'         (most specific match)
+	's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt.tar.gz'  (prefix still matches)
+	's3://somebucket/path/'      - URI: 's3://somebucket/path/otherfile.txt' (file only matches path-level registered fs)
+	's3"//somebucket/path/'      - URI: 's3://somebucket/path/'              (exact path-level match)
+	's3://somebucket/'           - URI: 's3://somebucket/test/file.txt'      (bucket-level match only)
+	's3://somebucket/'           - URI: 's3://somebucket/test/'              (still bucket-level match only)
+	's3://somebucket/'           - URI: 's3://somebucket/'                   (exact bucket-level match)
+	's3://some'                  - URI: 's3://some-other-bucket/'            (bucket-level match)
+	's3'                         - URI: 's3://other/'                        (scheme-level match, only)
+	's3'                         - URI: 's3://other/file.txt'                (scheme-level match, only)
+	's3'                         - URI: 's3://other/path/to/nowhere/'        (scheme-level match, only)
 
 */
 package vfssimple

--- a/vfssimple/doc.go
+++ b/vfssimple/doc.go
@@ -48,37 +48,37 @@ file system.
 
 	package main
 
-    import(
+	import(
 		"fmt"
 
-        "github.com/c2fo/vfs/v6/backend"
-        "github.com/c2fo/vfs/v6/backend/s3"
-        "github.com/c2fo/vfs/v6/vfssimple"
-    )
+		"github.com/c2fo/vfs/v6/backend"
+		"github.com/c2fo/vfs/v6/backend/s3"
+		"github.com/c2fo/vfs/v6/vfssimple"
+	)
 
-    func main() {
-        bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
-            AccessKeyID:     "key1",
-            SecretAccessKey: "secret1",
-            Region:          "us-west-2",
-        })
+	func main() {
+		bucketAuth := s3.NewFileSystem().WithOptions(s3.Options{
+			AccessKeyID:     "key1",
+			SecretAccessKey: "secret1",
+			Region:          "us-west-2",
+		})
 
-        fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
-            AccessKeyID:     "key2",
-            SecretAccessKey: "secret2",
-            Region:          "us-west-2",
-        })
+		fileAuth := s3.NewFileSystem().WithOptions(s3.Options{
+			AccessKeyID:     "key2",
+			SecretAccessKey: "secret2",
+			Region:          "us-west-2",
+		})
 
-        backend.Register("s3://bucket1/", bucketAuth)
-        backend.Register("s3://bucket2/file.txt", fileAuth)
+		backend.Register("s3://bucket1/", bucketAuth)
+		backend.Register("s3://bucket2/file.txt", fileAuth)
 
-        secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
-        publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
+		secureFile, _ := vfssimple.NewFile("s3://bucket2/file.txt")
+		publicLocation, _ := vfssimple.NewLocation("s3://bucket1/")
 
-        secureFile.CopyToLocation(publicLocation)
+		secureFile.CopyToLocation(publicLocation)
 
 		fmt.Printf("copied %s to %s\n", secureFile, publicLocation)
-    }
+	}
 
 Registered Backend Resolution
 

--- a/vfssimple/vfssimple.go
+++ b/vfssimple/vfssimple.go
@@ -1,10 +1,9 @@
 package vfssimple
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/c2fo/vfs/v6"
@@ -13,13 +12,20 @@ import (
 	"github.com/c2fo/vfs/v6/backend/azure"
 )
 
+var (
+	ErrMissingAuthority = errors.New("unable to determine uri authority ([user@]host[:port]) for network-based scheme")
+	ErrMissingScheme    = errors.New("unable to determine uri scheme")
+	ErrRegFsNotFound    = errors.New("no matching registered filesystem found")
+	ErrBlankURI         = errors.New("uri is blank")
+)
+
 // NewLocation is a convenience function that allows for instantiating a location based on a uri string. Any
 // backend file system is supported, though some may require prior configuration. See the docs for
 // specific requirements of each
 func NewLocation(uri string) (vfs.Location, error) {
 	fs, host, path, err := parseSupportedURI(uri)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create vfs.Location for uri %q: %w", uri, err)
 	}
 
 	return fs.NewLocation(host, path)
@@ -31,78 +37,101 @@ func NewLocation(uri string) (vfs.Location, error) {
 func NewFile(uri string) (vfs.File, error) {
 	fs, host, path, err := parseSupportedURI(uri)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create vfs.File for uri %q: %w", uri, err)
 	}
 
 	return fs.NewFile(host, path)
 }
 
-func parseSupportedURI(uri string) (vfs.FileSystem, string, string, error) {
-	var err error
+// parseURI attempts to parse a URI and validate that it returns required results
+func parseURI(uri string) (scheme, authority, path string, err error) {
+	// return early if blank uri
+	if uri == "" {
+		err = ErrBlankURI
+		return
+	}
+
+	// parse URI
 	var u *url.URL
 	u, err = url.Parse(uri)
 	if err != nil {
-		return nil, "", "", err
-	}
-	host := u.Host
-	path := u.Path
-	user := u.User
-	if user.String() != "" {
-		host = fmt.Sprintf("%s@%s", user, host)
+		err = fmt.Errorf("unknown url.Parse error: %w", err)
+		return
 	}
 
-	var fs vfs.FileSystem
-	for _, backendScheme := range backend.RegisteredBackends() {
-		// Azure
-		if azure.IsValidURI(u) {
-			host, path, err = azure.ParsePath(u.Path)
-		}
-
-		// Object-level backend
-		if strings.HasPrefix(uri, backendScheme) {
-			fs = backend.Backend(backendScheme)
-			break
-		}
-		// Bucket-level backend
-		volume := fmt.Sprintf("%s://%s/", u.Scheme, u.Host)
-		if volume == backendScheme {
-			fs = backend.Backend(backendScheme)
-			break
-		}
-
-		// Location-level backend
-		if isInPath(u, volume, backendScheme) {
-			fs = backend.Backend(backendScheme)
-			break
-		}
-
-		// Scheme-level backend
-		if u.Scheme == backendScheme {
-			fs = backend.Backend(backendScheme)
-		}
+	// validate schema
+	scheme = u.Scheme
+	if u.Scheme == "" {
+		err = ErrMissingScheme
+		return
 	}
 
-	if fs == nil {
-		err = fmt.Errorf("%s is an unsupported uri scheme", u.Scheme)
+	// validate authority
+	authority = u.Host
+	path = u.Path
+	if azure.IsValidURI(u) {
+		authority, path, err = azure.ParsePath(path)
 	}
 
-	return fs, host, path, err
+	if u.User.String() != "" {
+		authority = fmt.Sprintf("%s@%s", u.User, u.Host)
+	}
+	// network-based schemes require authority, but not file:// or mem://
+	if authority == "" && !(scheme == "file" || scheme == "mem") {
+		return "", "", "", ErrMissingAuthority
+	}
+
+	return
 }
 
-// isInPath will crawl down the provided url's path to see if it matches the registered root value
-// Example:
-//	 url: s3://bucket/root/path/to/file.txt
-//   root: s3://bucket/root/   <== Registered URI for file system.
+// parseSupportedURI checks if URI matches any backend name as prefix, capturing the longest(most specific) match found.
+// For instance, given registered backends with the names:
 //
-//   This would return true because the target url is within the root.
-func isInPath(u *url.URL, volume, root string) bool {
-	path := u.Path
-	paths := strings.Split(path, string(os.PathSeparator))
-	for i := range paths {
-		path := fmt.Sprintf("%s%s/", volume, filepath.Join(paths[0:i]...))
-		if path == root {
-			return true
+// 's3'                         - registered by default
+// 's3://somebucket/'           - perhaps this was registered using AWS access key id x
+// 's3://somebucket/path/'      - and this was registered using AWS access key id y
+// 's3://somebucket/path/a.txt' - and this was registered using AWS access key id z
+// 's3://some'                  - another contrived registered fs for bucket
+//
+// See the expected registered bucket name for each:
+//
+// 's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt'         (most specific match)
+// 's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt.tar.gz'  (prefix still matches)
+// 's3//somebucket/path/'       - URI: 's3://somebucket/path/otherfile.txt' (file only matches path-level registered fs)
+// 's3//somebucket/path/'       - URI: 's3://somebucket/path/'              (exact path-elve match)
+// 's3//somebucket/'            - URI: 's3://somebucket/test/file.txt'      (bucket-level match only)
+// 's3//somebucket/'            - URI: 's3://somebucket/test/'              (still bucket-level match only)
+// 's3//somebucket/'            - URI: 's3://somebucket/'                   (exact bucket-level match)
+// 's3//some'                   - URI: 's3://some-other-bucket/'            (bucket-level match)
+// 's3'                         - URI: 's3://other/'                        (scheme-level match, only)
+// 's3'                         - URI: 's3://other/file.txt'                (scheme-level match, only)
+// 's3'                         - URI: 's3://other/path/to/nowhere/'        (scheme-level match, only)
+func parseSupportedURI(uri string) (vfs.FileSystem, string, string, error) {
+	_, authority, path, err := parseURI(uri)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	var longest string
+	backends := backend.RegisteredBackends()
+	for _, backendName := range backends {
+		if strings.HasPrefix(uri, backendName) {
+			// The first match always becomes the longest
+			if longest == "" {
+				longest = backendName
+				continue
+			}
+
+			// we found a longer (more specific) backend prefix matching URI
+			if len(backendName) > len(longest) {
+				longest = backendName
+			}
 		}
 	}
-	return false
+
+	if longest == "" {
+		err = ErrRegFsNotFound
+	}
+
+	return backend.Backend(longest), authority, path, err
 }

--- a/vfssimple/vfssimple.go
+++ b/vfssimple/vfssimple.go
@@ -10,6 +10,8 @@ import (
 	"github.com/c2fo/vfs/v6/backend"
 	_ "github.com/c2fo/vfs/v6/backend/all" // register all backends
 	"github.com/c2fo/vfs/v6/backend/azure"
+	"github.com/c2fo/vfs/v6/backend/mem"
+	"github.com/c2fo/vfs/v6/backend/os"
 )
 
 var (
@@ -77,7 +79,7 @@ func parseURI(uri string) (scheme, authority, path string, err error) {
 		authority = fmt.Sprintf("%s@%s", u.User, u.Host)
 	}
 	// network-based schemes require authority, but not file:// or mem://
-	if authority == "" && !(scheme == "file" || scheme == "mem") {
+	if authority == "" && !(scheme == os.Scheme || scheme == mem.Scheme) {
 		return "", "", "", ErrMissingAuthority
 	}
 

--- a/vfssimple/vfssimple.go
+++ b/vfssimple/vfssimple.go
@@ -85,27 +85,7 @@ func parseURI(uri string) (scheme, authority, path string, err error) {
 }
 
 // parseSupportedURI checks if URI matches any backend name as prefix, capturing the longest(most specific) match found.
-// For instance, given registered backends with the names:
-//
-// 's3'                         - registered by default
-// 's3://somebucket/'           - perhaps this was registered using AWS access key id x
-// 's3://somebucket/path/'      - and this was registered using AWS access key id y
-// 's3://somebucket/path/a.txt' - and this was registered using AWS access key id z
-// 's3://some'                  - another contrived registered fs for bucket
-//
-// See the expected registered bucket name for each:
-//
-// 's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt'         (most specific match)
-// 's3://somebucket/path/a.txt' - URI: 's3://somebucket/path/a.txt.tar.gz'  (prefix still matches)
-// 's3//somebucket/path/'       - URI: 's3://somebucket/path/otherfile.txt' (file only matches path-level registered fs)
-// 's3//somebucket/path/'       - URI: 's3://somebucket/path/'              (exact path-elve match)
-// 's3//somebucket/'            - URI: 's3://somebucket/test/file.txt'      (bucket-level match only)
-// 's3//somebucket/'            - URI: 's3://somebucket/test/'              (still bucket-level match only)
-// 's3//somebucket/'            - URI: 's3://somebucket/'                   (exact bucket-level match)
-// 's3//some'                   - URI: 's3://some-other-bucket/'            (bucket-level match)
-// 's3'                         - URI: 's3://other/'                        (scheme-level match, only)
-// 's3'                         - URI: 's3://other/file.txt'                (scheme-level match, only)
-// 's3'                         - URI: 's3://other/path/to/nowhere/'        (scheme-level match, only)
+// See doc.go Registered Backend Resoltion seciton for examples.
 func parseSupportedURI(uri string) (vfs.FileSystem, string, string, error) {
 	_, authority, path, err := parseURI(uri)
 	if err != nil {

--- a/vfssimple/vfssimple_test.go
+++ b/vfssimple/vfssimple_test.go
@@ -1,0 +1,369 @@
+package vfssimple
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/c2fo/vfs/v6/backend"
+	"github.com/c2fo/vfs/v6/backend/s3"
+	"github.com/c2fo/vfs/v6/mocks"
+)
+
+func TestVFSSimple(t *testing.T) {
+	suite.Run(t, new(vfssimplesuite))
+}
+
+type vfssimplesuite struct {
+	suite.Suite
+}
+
+func (s *vfssimplesuite) TestParseURI() {
+	tests := []struct {
+		uri, message, scheme, authority, path string
+		err                                   error
+	}{
+		{
+			uri:     "",
+			err:     ErrBlankURI,
+			message: "cannot use an empty uri",
+		},
+		{
+			uri:     "asdf@asdf.com",
+			err:     ErrMissingScheme,
+			message: "email address is not a uri",
+		},
+		{
+			uri:     "1",
+			err:     ErrMissingScheme,
+			message: "integer is not a uri",
+		},
+		{
+			uri:     "host.com/path",
+			err:     ErrMissingScheme,
+			message: "missing scheme",
+		},
+		{
+			uri:     "s3.test.com",
+			err:     ErrMissingScheme,
+			message: "resembles, but is not, a uri",
+		},
+		{
+			uri:     "/some/path/to/file.txt",
+			err:     ErrMissingScheme,
+			message: "path-only is not a uri",
+		},
+		{
+			uri:     "s3://",
+			err:     ErrMissingAuthority,
+			message: "scheme only is not a uri without authority",
+		},
+		{
+			uri:     "\u007f",
+			err:     errors.New("net/url: invalid control character in URL"),
+			message: "invalid char causes parse error",
+		},
+		{
+			uri:       "fake://host.com/path/to/file.txt",
+			err:       nil,
+			message:   "valid uri for fake scheme",
+			scheme:    "fake",
+			authority: "host.com",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "file:///path/to/file.txt",
+			err:       nil,
+			message:   "valid file uri, no authority required",
+			scheme:    "file",
+			authority: "",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "file://c:/path/to/file.txt",
+			err:       nil,
+			message:   "valid file uri with authority(volume)",
+			scheme:    "file",
+			authority: "c:",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "file://c/path/to/file.txt",
+			err:       nil,
+			message:   "valid file uri with authority(volume), no colon",
+			scheme:    "file",
+			authority: "c",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "mem:///path/to/file.txt",
+			err:       nil,
+			message:   "valid mem uri, no authority (namespace) required",
+			scheme:    "mem",
+			authority: "",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "mem://namespace/path/to/file.txt",
+			err:       nil,
+			message:   "valid mem uri with namespace(authority)",
+			scheme:    "mem",
+			authority: "namespace",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "s3://mybucket/path/to/file.txt",
+			err:       nil,
+			message:   "valid s3 uri",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "gs://mybucket/path/to/file.txt",
+			err:       nil,
+			message:   "valid gs uri",
+			scheme:    "gs",
+			authority: "mybucket",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "https://myaccount.blob.core.windows.net/mycontainer/path/to/file.txt",
+			err:       nil,
+			message:   "valid azure uri",
+			scheme:    "https",
+			authority: "mycontainer",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "sftp://user@host.com/path/to/file.txt",
+			err:       nil,
+			message:   "valid sftp uri",
+			scheme:    "sftp",
+			authority: "user@host.com",
+			path:      "/path/to/file.txt",
+		},
+		{
+			uri:       "sftp://user@host.com:22/path/to/file.txt",
+			err:       nil,
+			message:   "valid sftp uri, with port",
+			scheme:    "sftp",
+			authority: "user@host.com:22",
+			path:      "/path/to/file.txt",
+		},
+	}
+
+	for _, test := range tests {
+		scheme, authority, path, err := parseURI(test.uri)
+		if test.err != nil {
+			s.Error(err, test.message)
+			if errors.Is(err, test.err) {
+				s.True(errors.Is(err, test.err), test.message)
+			} else {
+				// this is necessary since we can't recreate sentinel errors from url.Parse() to do errors.Is() comparison
+				s.Contains(err.Error(), test.err.Error(), test.message)
+			}
+		} else {
+			s.NoError(err, test.message)
+			s.Equal(test.scheme, scheme, test.message)
+			s.Equal(test.authority, authority, test.message)
+			s.Equal(test.path, path, test.message)
+		}
+	}
+}
+
+func (s *vfssimplesuite) TestParseSupportedURI() {
+	// register backend fs's that have a mock client injected that we can introspect in tests to ensure we right the right fs back
+	backend.Register("s3://mybucket/", s3.NewFileSystem().WithClient(getS3NamedClientMock("bucket1")))
+	backend.Register("s3://otherbucket/", s3.NewFileSystem().WithClient(getS3NamedClientMock("bucket2")))
+	backend.Register("s3://mybucket/path/", s3.NewFileSystem().WithClient(getS3NamedClientMock("path")))
+	backend.Register("s3://mybucket/path/file.txt", s3.NewFileSystem().WithClient(getS3NamedClientMock("file1")))
+	backend.Register("s3://mybucket/path/file.txt.pgp", s3.NewFileSystem().WithClient(getS3NamedClientMock("file2")))
+
+	tests := []struct {
+		uri, message, scheme, authority, path, regFS string
+		err                                          error
+	}{
+		{
+			uri:       "s3://mybucket/",
+			err:       nil,
+			message:   "registered bucket1",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/",
+			regFS:     "bucket1",
+		},
+		{
+			uri:       "s3://otherbucket/",
+			err:       nil,
+			message:   "registered bucket2",
+			scheme:    "s3",
+			authority: "otherbucket",
+			path:      "/",
+			regFS:     "bucket2",
+		},
+		{
+			uri:       "s3://mybucket/unregistered/path/",
+			err:       nil,
+			message:   "registered bucket, unregistered path",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/unregistered/path/",
+			regFS:     "bucket1",
+		},
+		{
+			uri:       "s3://mybucket/path/",
+			err:       nil,
+			message:   "registered bucket, registered path",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/path/",
+			regFS:     "path",
+		},
+		{
+			uri:       "s3://mybucket/path/and/more/path/",
+			err:       nil,
+			message:   "registered bucket, registered path with more unregistered path",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/path/and/more/path/",
+			regFS:     "path",
+		},
+		{
+			uri:       "s3://mybucket/path/file.txt",
+			err:       nil,
+			message:   "registered bucket, registered path with file1",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/path/file.txt",
+			regFS:     "file1",
+		},
+		{
+			uri:       "s3://mybucket/path/file.txt.tar.gz",
+			err:       nil,
+			message:   "registered bucket, registered path with file1 prefix", // *********** TODO: not totally sure about this test
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/path/file.txt.tar.gz",
+			regFS:     "file1",
+		},
+		{
+			uri:       "s3://mybucket/path/file.txt.pgp",
+			err:       nil,
+			message:   "registered bucket, registered path with file2",
+			scheme:    "s3",
+			authority: "mybucket",
+			path:      "/path/file.txt.pgp",
+			regFS:     "file2",
+		},
+	}
+
+	for _, test := range tests {
+		fs, authority, path, err := parseSupportedURI(test.uri)
+		if test.err != nil {
+			s.Error(err, test.message)
+			if errors.Is(err, test.err) {
+				s.True(errors.Is(err, test.err), test.message)
+			} else {
+				// this is necessary since we can't recreate sentinel errors from url.Parse() to do errors.Is() comparison
+				s.Contains(err.Error(), test.err.Error(), test.message)
+			}
+		} else {
+			s.NoError(err, test.message)
+			s.Equal(test.scheme, fs.Scheme(), test.message)
+			s.Equal(test.authority, authority, test.message)
+			s.Equal(test.path, path, test.message)
+			// check client for named registered mock
+			switch fs.Scheme() {
+			case "s3":
+				s3api, err := fs.(*s3.FileSystem).Client()
+				s.NoError(err, test.message)
+				if c, ok := s3api.(*namedS3ClientMock); ok {
+					s.Equal(c.RegName, test.regFS, test.message)
+				} else {
+					s.Fail("should have returned mock", test.message)
+				}
+			default:
+				s.Fail("we should have a case for returned fs type", test.message)
+			}
+		}
+	}
+}
+func (s *vfssimplesuite) TestNewFile() {
+	backend.Register("s3://filetest/path/", s3.NewFileSystem().WithClient(getS3NamedClientMock("filetest-path")))
+	backend.Register("s3://filetest/", s3.NewFileSystem().WithClient(getS3NamedClientMock("filetest-bucket")))
+
+	// success
+	goodURI := "s3://filetest/path/file.txt"
+	file, err := NewFile(goodURI)
+	s.NoError(err, "no error expected for NewFile")
+	s.IsType(file, &s3.File{}, "should be an s3.File")
+	s.Equal(file.URI(), goodURI)
+	s3api, err := file.Location().FileSystem().(*s3.FileSystem).Client()
+	s.NoError(err, "no error expected")
+	if c, ok := s3api.(*namedS3ClientMock); ok {
+		s.Equal(c.RegName, "filetest-path", "should be 'filetest-path', not 'filetest-bucket' or 's3'")
+	} else {
+		s.Fail("should have returned mock", "should not reach this")
+	}
+
+	// failure
+	badURI := "unknown://filetest/path/file.txt"
+	file, err = NewFile(badURI)
+	s.Error(err, "error expected for NewFile")
+	s.Nil(file, "file should be nil")
+	s.True(errors.Is(err, ErrRegFsNotFound))
+
+	badURI = ""
+	file, err = NewFile(badURI)
+	s.Error(err, "error expected for NewFile")
+	s.Nil(file, "file should be nil")
+	s.True(errors.Is(err, ErrBlankURI))
+}
+
+func (s *vfssimplesuite) TestNewLocation() {
+	backend.Register("s3://loctest/path/", s3.NewFileSystem().WithClient(getS3NamedClientMock("loctest-path")))
+	backend.Register("s3://loctest/", s3.NewFileSystem().WithClient(getS3NamedClientMock("loctest-bucket")))
+
+	// success
+	goodURI := "s3://loctest/path/to/here/"
+	loc, err := NewLocation(goodURI)
+	s.NoError(err, "no error expected for NewLocation")
+	s.IsType(loc, &s3.Location{}, "should be an s3.Location")
+	s.Equal(loc.URI(), goodURI)
+	s3api, err := loc.FileSystem().(*s3.FileSystem).Client()
+	s.NoError(err, "no error expected")
+	if c, ok := s3api.(*namedS3ClientMock); ok {
+		s.Equal(c.RegName, "loctest-path", "should be 'loctest-path', not 'loctest-bucket' or 's3'")
+	} else {
+		s.Fail("should have returned mock", "should not reach this")
+	}
+
+	// failure
+	badURI := "unknown://filetest/path/to/here/"
+	loc, err = NewLocation(badURI)
+	s.Error(err, "error expected for NewLocation")
+	s.Nil(loc, "location should be nil")
+	s.True(errors.Is(err, ErrRegFsNotFound))
+
+	badURI = ""
+	loc, err = NewLocation(badURI)
+	s.Error(err, "error expected for NewLocation")
+	s.Nil(loc, "location should be nil")
+	s.True(errors.Is(err, ErrBlankURI))
+}
+
+type namedS3ClientMock struct {
+	*mocks.S3API
+	RegName string
+}
+
+// getS3NamedClientMock returns an s3 client that satisfies the interface but we only really care about the name,
+// to introspect in the test return
+func getS3NamedClientMock(name string) *namedS3ClientMock {
+	return &namedS3ClientMock{
+		S3API:   &mocks.S3API{},
+		RegName: name,
+	}
+}


### PR DESCRIPTION
fixes #97 
- fixed azure helper func for vfssimple, ensuring it works on File URIs in addition to Location URIs
- fixed by updating vfssimple logic to ensure the most specific registered backend that matches a url is used, not just the first one it comes across.  Updated vfssimple docs.
- Added vfssimple tests.  Zero to 100% coverage.