### PR TITLE
Fix 92 gs integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - fixed linting issues with missing godoc on exported functions and new build tag formatting.
+- fixed #92 (broken by #72) where calling ListByPrefix() was fail from non-root locations when calling file-level prefixes.
 
 ## [6.0.1] - 2021-11-07
 ### Fixed

--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -35,9 +35,16 @@ func (l *Location) List() ([]string, error) {
 // List functions return only file basenames
 func (l *Location) ListByPrefix(filenamePrefix string) ([]string, error) {
 	prefix := utils.RemoveLeadingSlash(path.Join(l.prefix, filenamePrefix))
+	// add trailing slash to location prefix when file query prefix is empty:
+	//     NewLocation("/some/path/").ListByPrefix("")
+	// OR when it ended with a slash (for directory level searches):
+	//     NewLocation("/some/path/").ListByPrefix("dir1/dir2/")
+	// obviously we don't want to add a trailing slash if we're looking for a file prefix:
+	//     NewLocation("/some/path/").ListByPrefix("dir1/MyFilePrefix")
 	if filenamePrefix == "" || filenamePrefix[len(filenamePrefix)-1:] == "/" {
 		prefix = utils.EnsureTrailingSlash(prefix)
 	}
+	// remove location prefix altogether if this is the root
 	if prefix == "/" {
 		prefix = ""
 	}

--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -34,7 +34,13 @@ func (l *Location) List() ([]string, error) {
 // ListByPrefix returns a slice of file base names and any error, if any
 // List functions return only file basenames
 func (l *Location) ListByPrefix(filenamePrefix string) ([]string, error) {
-	prefix := utils.RemoveLeadingSlash(utils.EnsureTrailingSlash(path.Join(l.prefix, filenamePrefix)))
+	prefix := utils.RemoveLeadingSlash(path.Join(l.prefix, filenamePrefix))
+	if filenamePrefix == "" || filenamePrefix[len(filenamePrefix)-1:] == "/" {
+		prefix = utils.EnsureTrailingSlash(prefix)
+	}
+	if prefix == "/" {
+		prefix = ""
+	}
 	d := path.Dir(prefix)
 	q := &storage.Query{
 		Delimiter: "/",

--- a/backend/gs/location_test.go
+++ b/backend/gs/location_test.go
@@ -73,7 +73,7 @@ func (lt *locationTestSuite) TestList() {
 			if err != nil {
 				lt.T().Fatal(err)
 			}
-			t.Logf("log.URI() = %s", loc.URI())
+			t.Logf("location URI: %q", loc.URI())
 
 			files, err := loc.List()
 			if err != nil {
@@ -86,7 +86,7 @@ func (lt *locationTestSuite) TestList() {
 			if err != nil {
 				lt.T().Fatal(err)
 			}
-			t.Logf("log.URI() = %s", loc.URI())
+			t.Logf("location URI: %q", loc.URI())
 
 			t.Run("without slash", func(t *testing.T) {
 				files, err := loc.ListByPrefix(objectPrefix)
@@ -102,13 +102,21 @@ func (lt *locationTestSuite) TestList() {
 				}
 				assert.ElementsMatch(t, objectBaseNames, files, "should find all files in the location")
 			})
+			t.Run("include object-level filename prefix f2", func(t *testing.T) {
+				files, err := loc.ListByPrefix(objectPrefix + "/f2")
+				if err != nil {
+					lt.T().Fatal(err)
+				}
+				fileObjectBaseNames := []string{"f2.txt"}
+				assert.ElementsMatch(t, fileObjectBaseNames, files, "should find all files in the location matching f2")
+			})
 		})
 		lt.T().Run("list regex "+objectPrefix, func(t *testing.T) {
 			loc, err := fs.NewLocation(bucket, "/"+objectPrefix)
 			if err != nil {
 				lt.T().Fatal(err)
 			}
-			t.Logf("log.URI() = %s", loc.URI())
+			t.Logf("location URI: %q", loc.URI())
 
 			files, err := loc.ListByRegex(regexp.MustCompile("^f[02].txt$"))
 			if err != nil {

--- a/backend/testsuite/backend_integration_test.go
+++ b/backend/testsuite/backend_integration_test.go
@@ -111,7 +111,7 @@ func (s *vfsTestSuite) SetupSuite() {
 
 }
 
-//Test File
+// Test File
 func (s *vfsTestSuite) TestScheme() {
 	for scheme, location := range s.testLocations {
 		fmt.Printf("************** TESTING scheme: %s **************\n", scheme)
@@ -121,11 +121,11 @@ func (s *vfsTestSuite) TestScheme() {
 	}
 }
 
-//Test FileSystem
+// Test FileSystem
 func (s *vfsTestSuite) FileSystem(baseLoc vfs.Location) {
 	fmt.Println("****** testing vfs.FileSystem ******")
 
-	//setup FileSystem
+	// setup FileSystem
 	fs := baseLoc.FileSystem()
 	// NewFile initializes a File on the specified volume at path 'absFilePath'.
 	//
@@ -189,14 +189,14 @@ func (s *vfsTestSuite) FileSystem(baseLoc vfs.Location) {
 	}
 }
 
-//Test Location
+// Test Location
 func (s *vfsTestSuite) Location(baseLoc vfs.Location) {
 	fmt.Println("****** testing vfs.Location ******")
 
 	srcLoc, err := baseLoc.NewLocation("locTestSrc/")
 	s.NoError(err, "there should be no error")
 	defer func() {
-		//clean up srcLoc after test for OS
+		// clean up srcLoc after test for OS
 		if srcLoc.FileSystem().Scheme() == "file" {
 			exists, err := srcLoc.Exists()
 			if err != nil {
@@ -282,7 +282,7 @@ func (s *vfsTestSuite) Location(baseLoc vfs.Location) {
 	//
 	//   * ChangeDir accepts a relative location path.
 
-	//setup test
+	// setup test
 	cdTestLoc, err := srcLoc.NewLocation("chdirTest/")
 	s.NoError(err)
 
@@ -335,7 +335,7 @@ func (s *vfsTestSuite) Location(baseLoc vfs.Location) {
 	s.NoError(err)
 	s.True(exists, "baseLoc location exists check")
 
-	//setup list tests
+	// setup list tests
 	f1, err := srcLoc.NewFile("file1.txt")
 	s.NoError(err)
 	_, err = f1.Write([]byte("this is a test file"))
@@ -448,18 +448,18 @@ func (s *vfsTestSuite) Location(baseLoc vfs.Location) {
 	s.NoError(srcLoc.DeleteFile(f3.Name()), "deleteFile self.txt")
 	s.NoError(srcLoc.DeleteFile("somepath/that.txt"), "deleted relative path")
 
-	//should error if file doesn't exist
+	// should error if file doesn't exist
 	s.Error(srcLoc.DeleteFile(f1.Path()), "deleteFile trying to delete a file already deleted")
 
 }
 
-//Test File
+// Test File
 func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 	fmt.Println("****** testing vfs.File ******")
 	srcLoc, err := baseLoc.NewLocation("fileTestSrc/")
 	s.NoError(err)
 	defer func() {
-		//clean up srcLoc after test for OS
+		// clean up srcLoc after test for OS
 		if srcLoc.FileSystem().Scheme() == "file" {
 			exists, err := srcLoc.Exists()
 			if err != nil {
@@ -471,7 +471,7 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 		}
 	}()
 
-	//setup srcFile
+	// setup srcFile
 	srcFile, err := srcLoc.NewFile("srcFile.txt")
 	s.NoError(err)
 
@@ -585,7 +585,7 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 		s.NoError(err)
 		fmt.Printf("** location %s **\n", dstLoc)
 		defer func() {
-			//clean up dstLoc after test for OS
+			// clean up dstLoc after test for OS
 			if dstLoc.FileSystem().Scheme() == "file" {
 				exists, err := dstLoc.Exists()
 				if err != nil {
@@ -769,7 +769,7 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 		}
 
 		for _, test := range tests {
-			//setup src
+			// setup src
 			srcSpaces, err := srcLoc.NewFile(path.Join(test.Path, test.Filename))
 			s.NoError(err)
 			b, err := srcSpaces.Write([]byte("something"))
@@ -834,11 +834,11 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 	s.NoError(err)
 	s.Equal(uint64(0), size, "%s should be empty", touchedFile)
 
-	//capture last modified
+	// capture last modified
 	modified, err := touchedFile.LastModified()
 	s.NoError(err)
 	modifiedDeRef := *modified
-	//wait for eventual consistency
+	// wait for eventual consistency
 	time.Sleep(1 * time.Second)
 	err = touchedFile.Touch()
 	s.NoError(err)
@@ -858,7 +858,7 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 	s.NoError(err)
 	s.False(exists, "file no longer exists")
 
-	//The following blocks test that an error is thrown when these operations are called on a non-existent file
+	// The following blocks test that an error is thrown when these operations are called on a non-existent file
 	srcFile, err = srcLoc.NewFile("thisFileDoesNotExist")
 	s.NoError(err, "unexpected error creating file")
 
@@ -880,7 +880,7 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 	_, err = srcFile.Read(make([]byte, 1))
 	s.Error(err, "expected error because file does not exist")
 
-	//end existence tests
+	// end existence tests
 
 }
 
@@ -914,7 +914,7 @@ func (s *vfsTestSuite) gsList(baseLoc vfs.Location) {
 
 	ctx := context.Background()
 
-	//write zero length object
+	// write zero length object
 	writer := objHandle.NewWriter(ctx)
 	_, err = writer.Write([]byte(""))
 	s.NoError(err)
@@ -953,7 +953,7 @@ func sftpRemoveAll(location *sftp.Location) error {
 		return err
 	}
 
-	//recursively remove directory
+	// recursively remove directory
 	return recursiveSFTPRemove(location.Path(), client)
 }
 
@@ -963,7 +963,7 @@ func recursiveSFTPRemove(absPath string, client sftp.Client) error {
 	err := client.Remove(absPath)
 	// if we succeeded or it didn't exist, just return
 	if err == nil || os.IsNotExist(err) {
-		//success
+		// success
 		return nil
 	}
 
@@ -982,7 +982,7 @@ func recursiveSFTPRemove(absPath string, client sftp.Client) error {
 	var rErr error
 	for _, child := range children {
 		childName := child.Name()
-		//TODO: what about symlinks to directories? we're not recursing into them, which I think is right
+		// TODO: what about symlinks to directories? we're not recursing into them, which I think is right
 		//      if we need to, we'd do:
 		//          if child.Mode() & ModeSymLink != 0 {
 		// 	          do something


### PR DESCRIPTION
fixes #92 (broken by #72) where calling ListByPrefix() was fail from non-root locations when calling file-level prefixes like:
```go
	fs := gs.NewFileSystem()
	loc, _ := fs.NewLocation("mybucket", "/some/path/")
        filenamePrefix := "xyz"
        files, _ := loc.ListByPrefix(xyz)
```
Files used to always be empty.  This is now fixed and works in integration tests.  Also added to unit tests to cover this.