### PR TITLE
Add DeleteAllVersions option support for azure to remove all versions of a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+- Add DeleteAllVersions option support for Azure to remove all versions of a file
+
 ## [6.4.0]
 
 ### Added

--- a/backend/azure/client.go
+++ b/backend/azure/client.go
@@ -232,12 +232,6 @@ func (a *DefaultClient) DeleteAllVersions(file vfs.File) error {
 	containerURL := azblob.NewContainerURL(*URL, a.pipeline)
 	blobURL := containerURL.NewBlockBlobURL(utils.RemoveLeadingSlash(file.Path()))
 
-	// Delete the blob so that latest version is moved to previous versions
-	_, err = blobURL.Delete(context.Background(), azblob.DeleteSnapshotsOptionNone, azblob.BlobAccessConditions{})
-	if err != nil {
-		return err
-	}
-
 	versions, err := a.getBlobVersions(containerURL, utils.RemoveLeadingSlash(file.Location().Path()))
 	if err != nil {
 		return err

--- a/backend/azure/file.go
+++ b/backend/azure/file.go
@@ -216,12 +216,15 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 		}
 	}
 
-	if deleteAllVersions {
-		return client.DeleteAllVersions(f)
-	} else {
-		return client.Delete(f)
+	if err = client.Delete(f); err != nil {
+		return err
 	}
 
+	if deleteAllVersions {
+		return client.DeleteAllVersions(f)
+	}
+
+	return err
 }
 
 // LastModified returns the last modified time as a time.Time

--- a/backend/azure/file.go
+++ b/backend/azure/file.go
@@ -216,7 +216,7 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 		}
 	}
 
-	if err = client.Delete(f); err != nil {
+	if err := client.Delete(f); err != nil {
 		return err
 	}
 

--- a/backend/azure/file_test.go
+++ b/backend/azure/file_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/c2fo/vfs/v6"
+	"github.com/c2fo/vfs/v6/options/delete"
 	"github.com/c2fo/vfs/v6/utils"
 )
 
@@ -189,7 +190,26 @@ func (s *FileTestSuite) TestDelete() {
 	s.NoError(f.Delete(), "The delete should succeed so there should be no error")
 }
 
-func (s *FileTestSuite) TestDelete_NonExistantFile() {
+func (s *FileTestSuite) TestDeleteWithDeleteAllVersionsOption() {
+	client := MockAzureClient{}
+	fs := NewFileSystem().WithClient(&client)
+
+	f, err := fs.NewFile("test-container", "/foo.txt")
+	s.NoError(err, "The path is valid so no error should be returned")
+	s.NoError(f.Delete(delete.WithDeleteAllVersions()), "The delete should succeed so there should be no error")
+}
+
+func (s *FileTestSuite) TestDeleteWithDeleteAllVersionsOption_Error() {
+	client := MockAzureClient{ExpectedError: errors.New("i always error")}
+	fs := NewFileSystem().WithClient(&client)
+
+	f, err := fs.NewFile("test-container", "/foo.txt")
+	s.NoError(err, "The path is valid so no error should be returned")
+	err = f.Delete(delete.WithDeleteAllVersions())
+	s.Error(err, "If the file does not exist we get an error")
+}
+
+func (s *FileTestSuite) TestDelete_NonExistentFile() {
 	client := MockAzureClient{ExpectedError: errors.New("i always error")}
 	fs := NewFileSystem().WithClient(&client)
 

--- a/backend/azure/mock_client.go
+++ b/backend/azure/mock_client.go
@@ -61,6 +61,11 @@ func (a *MockAzureClient) Delete(file vfs.File) error {
 	return a.ExpectedError
 }
 
+// DeleteAllVersions returns the value of ExpectedError
+func (a *MockAzureClient) DeleteAllVersions(file vfs.File) error {
+	return a.ExpectedError
+}
+
 // MockStorageError is a mock for the azblob.StorageError interface
 type MockStorageError struct {
 	azblob.ResponseError

--- a/backend/gs/file.go
+++ b/backend/gs/file.go
@@ -226,6 +226,15 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 		}
 	}
 
+	handle, err := f.getObjectHandle()
+	if err != nil {
+		return err
+	}
+	err = handle.Delete(f.fileSystem.ctx)
+	if err != nil {
+		return err
+	}
+
 	if deleteAllVersions {
 		handles, err := f.getObjectGenerationHandles()
 		if err != nil {
@@ -237,14 +246,8 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 				return err
 			}
 		}
-		return nil
-	} else {
-		handle, err := f.getObjectHandle()
-		if err != nil {
-			return err
-		}
-		return handle.Delete(f.fileSystem.ctx)
 	}
+	return nil
 }
 
 // Touch creates a zero-length file on the vfs.File if no File exists.  Update File's last modified timestamp.

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -205,6 +205,14 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 		}
 	}
 
+	_, err = client.DeleteObject(&s3.DeleteObjectInput{
+		Key:    &f.key,
+		Bucket: &f.bucket,
+	})
+	if err != nil {
+		return err
+	}
+
 	if deleteAllVersions {
 		objectVersions, err := f.getAllObjectVersions(client)
 		if err != nil {
@@ -220,11 +228,6 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 				return err
 			}
 		}
-	} else {
-		_, err = client.DeleteObject(&s3.DeleteObjectInput{
-			Key:    &f.key,
-			Bucket: &f.bucket,
-		})
 	}
 
 	return err

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -591,7 +591,8 @@ func (ts *fileTestSuite) TestDeleteWithDeleteAllVersionsOptionError() {
 	}
 	s3apiMock.On("ListObjectVersions", mock.AnythingOfType("*s3.ListObjectVersionsInput")).Return(&versOutput, nil)
 	s3apiMock.On("DeleteObject", &s3.DeleteObjectInput{Key: &testFileName, Bucket: &bucket}).Return(&s3.DeleteObjectOutput{}, nil)
-	s3apiMock.On("DeleteObject", &s3.DeleteObjectInput{Key: &testFileName, Bucket: &bucket, VersionId: &verIds[0]}).Return(nil, errors.New("something went wrong"))
+	s3apiMock.On("DeleteObject", &s3.DeleteObjectInput{Key: &testFileName, Bucket: &bucket, VersionId: &verIds[0]}).
+		Return(nil, errors.New("something went wrong"))
 
 	err := testFile.Delete(delete.WithDeleteAllVersions())
 	ts.NotNil(err, "Delete should return an error if s3 api had error.")

--- a/backend/s3/location_test.go
+++ b/backend/s3/location_test.go
@@ -317,7 +317,7 @@ func (lt *locationTestSuite) TestDeleteFileWithDeleteAllVersionsOption() {
 	err = loc.DeleteFile("filename.txt", delete.WithDeleteAllVersions())
 	lt.Nil(err, "Successful delete should not return an error.")
 	lt.s3apiMock.AssertExpectations(lt.T())
-	lt.s3apiMock.AssertNumberOfCalls(lt.T(), "DeleteObject", 2)
+	lt.s3apiMock.AssertNumberOfCalls(lt.T(), "DeleteObject", 3)
 }
 
 func TestLocation(t *testing.T) {

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -194,6 +194,15 @@ func (a *DefaultClient) Delete(file vfs.File) error
 ```
 Delete deletes the given file from Azure Blob Storage.
 
+#### func (*DefaultClient) DeleteAllVersions
+
+```go
+func (a *DefaultClient) Delete(file vfs.File) error
+```
+
+Deletes the file blob using Azure's delete blob api, then each version of the blob is deleted using Azure's delete api. NOTE that if soft deletion is enabled for the blobs in the storage account, each version will be marked as deleted and will get permanently deleted by Azure as per the soft deletion policy. Returns any error returned by the API.
+
+
 #### func (*DefaultClient) Download
 
 ```go
@@ -287,9 +296,9 @@ be done to the new file.
 #### func (*File) Delete
 
 ```go
-func (f *File) Delete() error
+func (f *File) Delete(opts ...options.DeleteOption) error
 ```
-Delete deletes the file.
+Deletes the file using Azure's delete blob api. If opts is of type DeleteAllVersions, after deleting the blob, each version of the blob is deleted using Azure's delete api. NOTE that if soft deletion is enabled for the blobs, each version will be marked as deleted and will get permanently deleted by Azure as per the soft deletion policy. Returns any error returned by the API.
 
 #### func (*File) Exists
 


### PR DESCRIPTION
Added support for delete all versions in Azure.

Approach:
DeleteAllVersions 
- deletes the blob (this moves the latest version to previous versions)
- then loops through all the versions of the blob and deletes each version
   - if blobs have soft deletion enabled, this will mark each version as deleted and Azure will permanently delete them as per soft delete policy
   - if blobs don't have soft deletion enabled, this will immediately deletes all the versions