### PR TITLE
Fix mem tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed golangci-lint issues
+- Fixed #90 - integration were tests failing on move for mem-to-mem move and bad mutex unlock call when doing mem to non-mem move
 
 ## [6.4.0]
 

--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -375,8 +375,8 @@ func (f *File) MoveToLocation(location vfs.Location) (vfs.File, error) {
 				return file, nil
 			}
 		}
+		f.memFile.location.FileSystem().(*FileSystem).mu.Unlock()
 	}
-	f.memFile.location.FileSystem().(*FileSystem).mu.Unlock()
 	// if the file doesn't yet exist at the location, create it there
 	newFile, err := location.NewFile(f.Name())
 	if err != nil {
@@ -447,7 +447,7 @@ func (f *File) Delete(_ ...options.DeleteOption) error {
 			thisObj.i = nil
 			thisObj = nil
 			// setting that key to nil so it truly no longer lives on this system
-			mapRef[loc.Volume()][str] = nil
+			delete(mapRef[loc.Volume()], str)
 		}
 	}
 


### PR DESCRIPTION
fixes #90 - remove filesystem file map entry on delete.  unlock mutex only in coxtext of mem-to-mem moves