### PR TITLE
List azure blob versions using file path not location path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Fixed
+- Fixed the azure deleteAllVersions to fetch versions using file path instead of location path
+
 ## [6.5.0]
 
 ### Added

--- a/backend/azure/client.go
+++ b/backend/azure/client.go
@@ -232,7 +232,7 @@ func (a *DefaultClient) DeleteAllVersions(file vfs.File) error {
 	containerURL := azblob.NewContainerURL(*URL, a.pipeline)
 	blobURL := containerURL.NewBlockBlobURL(utils.RemoveLeadingSlash(file.Path()))
 
-	versions, err := a.getBlobVersions(containerURL, utils.RemoveLeadingSlash(file.Location().Path()))
+	versions, err := a.getBlobVersions(containerURL, utils.RemoveLeadingSlash(file.Path()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While testing with multiple files in azure, I noticed that I was retrieving versions of blob using the file location path so ended up getting versions that didn't belong to the file blob so the deletes failed. Fixing the code to fetch versions using file path instead of location path.