### PR TITLE
Fix problem when calling Delete method on mock.File

### DIFF
--- a/mocks/File.go
+++ b/mocks/File.go
@@ -80,6 +80,8 @@ func (_m *File) Delete(deleteOpts ...options.DeleteOption) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(...options.DeleteOption) error); ok {
 		r0 = rf(deleteOpts...)
+	} else if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
When calling the Delete method in mock.File with no parameters we were getting a panic.