### PR TITLE
Fixed in-memory implementation edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+- fixed edge cases where in-memory files either weren't found when they should be, or didn't reset state on new writes
+
 ### Fixed
 - Replaced pre-generated ssh keypair in sftp options tests with auto-generated pair to remediate false-positive security alerts for hard-coded credentials.
 

--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -187,6 +187,10 @@ func (f *File) Write(p []byte) (int, error) {
 			return 0, err
 		}
 	}
+	// If it's a new write session, assume data will be overwritten
+	if f.memFile.writeBuffer.Len() == 0 && len(f.memFile.contents) > 0 {
+		f.memFile.contents = []byte{}
+	}
 	f.memFile.Lock()
 	num, err := f.memFile.writeBuffer.Write(p)
 	f.memFile.lastModified = time.Now()

--- a/backend/mem/file_test.go
+++ b/backend/mem/file_test.go
@@ -753,6 +753,25 @@ func (s *memFileTest) TestStringer() {
 
 }
 
+func (s *memFileTest) TestFileNewWrite() {
+	file, err := s.fileSystem.NewFile("", "/test_files/lots/of/directories/here/we/go/test.txt")
+	s.Require().NoError(err)
+	_, err = file.Write([]byte("hello world"))
+	s.Require().NoError(err)
+	s.Require().NoError(file.Close())
+
+	data, err := ioutil.ReadAll(file)
+	s.Equal("hello world", string(data))
+
+	// Re-write the same data should not append
+	_, err = file.Write([]byte("hello world"))
+	s.Require().NoError(err)
+	s.Require().NoError(file.Close())
+
+	data, err = ioutil.ReadAll(file)
+	s.Equal("hello world", string(data))
+}
+
 func TestMemFile(t *testing.T) {
 	suite.Run(t, new(memFileTest))
 	_ = os.Remove("test_files/new.txt")

--- a/backend/mem/file_test.go
+++ b/backend/mem/file_test.go
@@ -760,7 +760,8 @@ func (s *memFileTest) TestFileNewWrite() {
 	s.Require().NoError(err)
 	s.Require().NoError(file.Close())
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
+	s.Require().NoError(err)
 	s.Equal("hello world", string(data))
 
 	// Re-write the same data should not append
@@ -768,7 +769,8 @@ func (s *memFileTest) TestFileNewWrite() {
 	s.Require().NoError(err)
 	s.Require().NoError(file.Close())
 
-	data, err = ioutil.ReadAll(file)
+	data, err = io.ReadAll(file)
+	s.Require().NoError(err)
 	s.Equal("hello world", string(data))
 }
 

--- a/backend/mem/location.go
+++ b/backend/mem/location.go
@@ -170,7 +170,8 @@ func (l *Location) NewFile(relFilePath string) (vfs.File, error) {
 	// file already exists. if it does, return a reference to it
 	mapRef := l.fileSystem.fsMap
 	if _, ok := mapRef[l.volume]; ok {
-		fileList := mapRef[l.volume].filesHere(l.Path())
+		relativeLocationPath := utils.EnsureTrailingSlash(path.Dir(path.Join(l.Path(), relFilePath)))
+		fileList := mapRef[l.volume].filesHere(relativeLocationPath)
 		for _, file := range fileList {
 			if file.name == path.Base(relFilePath) {
 				fileCopy := deepCopy(file)

--- a/backend/mem/location_test.go
+++ b/backend/mem/location_test.go
@@ -1,6 +1,7 @@
 package mem
 
 import (
+	"io/ioutil"
 	"path"
 	"regexp"
 	"testing"
@@ -311,6 +312,31 @@ func (s *memLocationTest) TestDeleteFile() {
 	s.False(existence1)
 	s.NoError(eerr1, "unexpected existence error")
 
+}
+
+// TestWriteExistingFile tests that initalizing a pre-existing file from a location, using a relative path will not result
+// in a blank file
+func (s *memLocationTest) TestWriteExistingFile() {
+
+	newFile, err := s.fileSystem.NewFile("", "/path/to/file/bar.txt")
+	s.NoError(err, "unexpected error creating a new file")
+
+	_, err = newFile.Write([]byte("hello world"))
+	s.Require().NoError(err)
+	s.Require().NoError(newFile.Close())
+
+	location, err := s.fileSystem.NewLocation("", "/path/")
+	s.Require().NoError(err)
+
+	file, err := location.NewFile("to/file/bar.txt")
+	s.Require().NoError(err)
+
+	exists, err := file.Exists()
+	s.Require().NoError(err)
+	s.True(exists)
+
+	data, err := ioutil.ReadAll(file)
+	s.Equal("hello world", string(data))
 }
 
 func TestMemLocation(t *testing.T) {

--- a/backend/mem/location_test.go
+++ b/backend/mem/location_test.go
@@ -1,7 +1,7 @@
 package mem
 
 import (
-	"io/ioutil"
+	"io"
 	"path"
 	"regexp"
 	"testing"
@@ -314,7 +314,7 @@ func (s *memLocationTest) TestDeleteFile() {
 
 }
 
-// TestWriteExistingFile tests that initalizing a pre-existing file from a location, using a relative path will not result
+// TestWriteExistingFile tests that initializing a pre-existing file from a location, using a relative path will not result
 // in a blank file
 func (s *memLocationTest) TestWriteExistingFile() {
 
@@ -335,7 +335,8 @@ func (s *memLocationTest) TestWriteExistingFile() {
 	s.Require().NoError(err)
 	s.True(exists)
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
+	s.Require().NoError(err)
 	s.Equal("hello world", string(data))
 }
 


### PR DESCRIPTION
There were a couple of edge cases that this fixed:

1. Re-writing data on an in-memory file would previously append data to the existing file rather than overwrite. I fixed this to be consistent with other implementations:

```
file.Write([]byte("foo bar")
file.Close()
// contents: "foo bar"

file.Write([]byte("foo bar")
file.Close()
// contents: "foo barfoo bar"
```
2. Fixed issue where creating a file in a file system, and then opening it from a relative path in an initialized location yielded no file contents

```
fileSystem.NewFile("", "/path/to/some/file.txt")
file.Write([]byte("foo bar")
// contents: "foo bar"

location, _ := fileSystem.NewLocation("", "/path/to/")
f, _ := location.NewFile("some/file.txt")
ioutil.ReadAll(f) // contents: ""
```