### PR TITLE
Resolve failing golangci-lint / lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feature/fixLint
   pull_request:
     branches:
       - master

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/fixLint
   pull_request:
     branches:
       - master

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,6 @@
 name: golangci-lint
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,12 @@
 name: golangci-lint
 on:
-  workflow_dispatch:
   push:
     tags:
       - v*
     branches:
       - master
       - main
+      - feature/fixLint
   pull_request:
 jobs:
   golangci:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - main
-      - feature/fixLint
   pull_request:
 jobs:
   golangci:

--- a/backend/azure/doc.go
+++ b/backend/azure/doc.go
@@ -1,63 +1,63 @@
 /*
 Package azure Microsoft Azure Blob Storage VFS Implementation
 
-Usage
+# Usage
 
 Rely on github.com/c2fo/vfs/backend
 
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/c2fo/vfs/v6/backend/azure"
-  )
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/c2fo/vfs/v6/backend/azure"
+	)
 
-  func UseFs() error {
-      fs := backend.Backend(azure.Scheme)
-      ...
-  }
+	func UseFs() error {
+	    fs := backend.Backend(azure.Scheme)
+	    ...
+	}
 
 Or call directly:
 
-  import "github.com/c2fo/vfs/v6/backend/azure"
+	import "github.com/c2fo/vfs/v6/backend/azure"
 
-  func DoSomething() {
-      fs := azure.NewFilesystem()
-      ...
-  }
+	func DoSomething() {
+	    fs := azure.NewFilesystem()
+	    ...
+	}
 
 azure can be augmented with the following implementation-specific methods.  Backend returns vfs.Filesystem interface so it
 would have to be cast as azure.Filesystem to use the following:
 
-  func DoSomething() {
+	func DoSomething() {
 
-      ...
+	    ...
 
-      // cast if fs was created using backend.Backend().  Not necessary if created directly from azure.NewFilesystem().
-      fs = fs.(azure.Filesystem)
+	    // cast if fs was created using backend.Backend().  Not necessary if created directly from azure.NewFilesystem().
+	    fs = fs.(azure.Filesystem)
 
-      // to pass in client options
-      fs = fs.WithOptions(
-          azure.Options{
-              AccountName: "...",
-              AccountKey: "...
-          },
-      )
+	    // to pass in client options
+	    fs = fs.WithOptions(
+	        azure.Options{
+	            AccountName: "...",
+	            AccountKey: "...
+	        },
+	    )
 
-      // to pass specific client, for instance mock client
-      client, _ := azure.NewClient(MockAzureClient{...})
-      fs = fs.WithClient(client)
-  }
+	    // to pass specific client, for instance mock client
+	    client, _ := azure.NewClient(MockAzureClient{...})
+	    fs = fs.WithClient(client)
+	}
 
-Authentication
+# Authentication
 
 Authentication, by default, occurs automatically when Client() is called. It looks for credentials in the following places,
 preferring the first location found:
 
-  1. When the ENV vars VFS_AZURE_ENV_NAME, VFS_AZURE_STORAGE_ACCOUNT, VFS_AZURE_TENANT_ID, VFS_AZURE_CLIENT_ID, and
-     VFS_AZURE_CLIENT_SECRET, authentication is performed using an OAuth Token Authenticator.  This will allow access
-     to containers from multiple storage accounts.
-  2. The ENV vars VFS_AZURE_STORAGE_ACCOUNT and VFS_AZURE_STORAGE_KEY, a shared key authenticator is used.  This will
-     allow access to any containers owned by the designated storage account.
-  3. If none of the above are present, then an anonymous authenticator is created and only publicly accessible blobs
-     will be available
+ 1. When the ENV vars VFS_AZURE_ENV_NAME, VFS_AZURE_STORAGE_ACCOUNT, VFS_AZURE_TENANT_ID, VFS_AZURE_CLIENT_ID, and
+    VFS_AZURE_CLIENT_SECRET, authentication is performed using an OAuth Token Authenticator.  This will allow access
+    to containers from multiple storage accounts.
+ 2. The ENV vars VFS_AZURE_STORAGE_ACCOUNT and VFS_AZURE_STORAGE_KEY, a shared key authenticator is used.  This will
+    allow access to any containers owned by the designated storage account.
+ 3. If none of the above are present, then an anonymous authenticator is created and only publicly accessible blobs
+    will be available
 */
 package azure

--- a/backend/azure/options.go
+++ b/backend/azure/options.go
@@ -44,13 +44,14 @@ type Options struct {
 }
 
 // NewOptions creates a new Options struct by populating values from environment variables.
-//   Env Vars:
-//     *VFS_AZURE_STORAGE_ACCOUNT
-//     *VFS_AZURE_STORAGE_ACCESS_KEY
-//     *VFS_AZURE_TENANT_ID
-//     *VFS_AZURE_CLIENT_ID
-//     *VFS_AZURE_CLIENT_SECRET
-//     *VFS_AZURE_ENV_NAME
+//
+//	Env Vars:
+//	  *VFS_AZURE_STORAGE_ACCOUNT
+//	  *VFS_AZURE_STORAGE_ACCESS_KEY
+//	  *VFS_AZURE_TENANT_ID
+//	  *VFS_AZURE_CLIENT_ID
+//	  *VFS_AZURE_CLIENT_SECRET
+//	  *VFS_AZURE_ENV_NAME
 func NewOptions() *Options {
 	return &Options{
 		AccountName:            os.Getenv("VFS_AZURE_STORAGE_ACCOUNT"),
@@ -65,11 +66,11 @@ func NewOptions() *Options {
 
 // Credential returns an azblob.Credential struct based on how options are configured.  Options are checked
 // and evaluated in the following order:
-//    1. If TenantID, ClientID, and ClientSecret are non-empty, return azblob.TokenCredential.  This form of authentication
-//       is used with service accounts and can be used to access containers across multiple storage accounts.
-//    2. If AccountName, and AccountKey are non-empty, return azblob.SharedKeyCredential.  This form or authentication
-//       is used with storage accounts and only provides access to a single storage account.
-//    3. Returns an anonymous credential.  This allows access only to public blobs.
+//  1. If TenantID, ClientID, and ClientSecret are non-empty, return azblob.TokenCredential.  This form of authentication
+//     is used with service accounts and can be used to access containers across multiple storage accounts.
+//  2. If AccountName, and AccountKey are non-empty, return azblob.SharedKeyCredential.  This form or authentication
+//     is used with storage accounts and only provides access to a single storage account.
+//  3. Returns an anonymous credential.  This allows access only to public blobs.
 func (o *Options) Credential() (azblob.Credential, error) {
 	if o.tokenCredentialFactory == nil {
 		o.tokenCredentialFactory = &DefaultTokenCredentialFactory{}

--- a/backend/doc.go
+++ b/backend/doc.go
@@ -4,71 +4,72 @@ backend.Register("some name", vfs.FileSystem)
 
 In this way, a caller of vfs backends can simply load the backend file system (and ONLY those needed) and begin using it:
 
-  package main
+	package main
 
-  // import backend and each backend you intend to use
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/c2fo/vfs/v6/backend/os"
-      "github.com/c2fo/vfs/v6/backend/s3"
-  )
+	// import backend and each backend you intend to use
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/c2fo/vfs/v6/backend/os"
+	    "github.com/c2fo/vfs/v6/backend/s3"
+	)
 
-  func main() {
-     var err error
-     var osfile, s3file vfs.File
+	func main() {
+	   var err error
+	   var osfile, s3file vfs.File
 
-      // THEN begin using the file systems
-      osfile, err = backend.Backend(os.Scheme).NewFile("", "/path/to/file.txt")
-      if err != nil {
-          panic(err)
-      }
+	    // THEN begin using the file systems
+	    osfile, err = backend.Backend(os.Scheme).NewFile("", "/path/to/file.txt")
+	    if err != nil {
+	        panic(err)
+	    }
 
-      s3file, err = backend.Backend(s3.Scheme).NewFile("mybucket", "/some/file.txt")
-      if err != nil {
-          panic(err)
-      }
+	    s3file, err = backend.Backend(s3.Scheme).NewFile("mybucket", "/some/file.txt")
+	    if err != nil {
+	        panic(err)
+	    }
 
-      err = osfile.CopyTo(s3file)
-      if err != nil {
-          panic(err)
-      }
-  }
+	    err = osfile.CopyTo(s3file)
+	    if err != nil {
+	        panic(err)
+	    }
+	}
 
-Development
+# Development
 
 To create your own backend, you must create a package that implements the interfaces: vfs.FileSystem, vfs.Location, and vfs.File.
 Then ensure it registers itself on load:
 
-  package myexoticfilesystem
+	package myexoticfilesystem
 
-  import(
-      ...
-      "github.com/c2fo/vfs/v6"
-      "github.com/c2fo/vfs/v6/backend"
-  )
+	import(
+	    ...
+	    "github.com/c2fo/vfs/v6"
+	    "github.com/c2fo/vfs/v6/backend"
+	)
 
-  // IMPLEMENT vfs interfaces
-  ...
+	// IMPLEMENT vfs interfaces
+	...
 
-  // register backend
-  func init() {
-      backend.Register("exfs", &MyExoticFilesystem{})
-  }
+	// register backend
+	func init() {
+	    backend.Register("exfs", &MyExoticFilesystem{})
+	}
 
 Then do use it in some other package do
-  package MyExoticFileSystem
 
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/acme/myexoticfilesystem"
-  )
+	package MyExoticFileSystem
 
-  ...
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/acme/myexoticfilesystem"
+	)
 
-  func useNewBackend() error {
-      myExoticFs, err = backend.Backend(myexoticfilesystem.Scheme)
-      ...
-  }
+	...
+
+	func useNewBackend() error {
+	    myExoticFs, err = backend.Backend(myexoticfilesystem.Scheme)
+	    ...
+	}
 
 That's it.  Simple.
 */

--- a/backend/gs/doc.go
+++ b/backend/gs/doc.go
@@ -1,75 +1,74 @@
 /*
 Package gs Google Cloud Storage VFS implementation.
 
-Usage
+# Usage
 
 Rely on github.com/c2fo/vfs/backend
 
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/c2fo/vfs/v6/backend/gs"
-  )
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/c2fo/vfs/v6/backend/gs"
+	)
 
-  func UseFs() error {
-      fs := backend.Backend(gs.Scheme)
-      ...
-  }
+	func UseFs() error {
+	    fs := backend.Backend(gs.Scheme)
+	    ...
+	}
 
 Or call directly:
 
-  import "github.com/c2fo/vfs/v6/backend/gs"
+	import "github.com/c2fo/vfs/v6/backend/gs"
 
-  func DoSomething() {
-      fs := gs.NewFilesystem()
-      ...
-  }
+	func DoSomething() {
+	    fs := gs.NewFilesystem()
+	    ...
+	}
 
 gs can be augmented with the following implementation-specific methods.  Backend returns vfs.Filesystem interface so it
 would have to be cast as gs.Filesystem to use the following:
 
-  func DoSomething() {
+	func DoSomething() {
 
-      ...
+	    ...
 
-      // cast if fs was created using backend.Backend().  Not necessary if created directly from gs.NewFilesystem().
-      fs = fs.(gs.Filesystem)
+	    // cast if fs was created using backend.Backend().  Not necessary if created directly from gs.NewFilesystem().
+	    fs = fs.(gs.Filesystem)
 
-      // to use your own "context"
-      ctx := context.Background()
-      fs = fs.WithContext(ctx)
+	    // to use your own "context"
+	    ctx := context.Background()
+	    fs = fs.WithContext(ctx)
 
-      // to pass in client options
-      fs = fs.WithOptions(
-          gs.Options{
-              CredentialFile: "/root/.gcloud/account.json",
-              Scopes:         []string{"ScopeReadOnly"},
-              //default scope is "ScopeFullControl"
-          },
-      )
+	    // to pass in client options
+	    fs = fs.WithOptions(
+	        gs.Options{
+	            CredentialFile: "/root/.gcloud/account.json",
+	            Scopes:         []string{"ScopeReadOnly"},
+	            //default scope is "ScopeFullControl"
+	        },
+	    )
 
-      // to pass specific client, for instance no-auth client
-      ctx := context.Background()
-      client, _ := storage.NewClient(ctx, option.WithoutAuthentication())
-      fs = fs.WithClient(client)
-  }
+	    // to pass specific client, for instance no-auth client
+	    ctx := context.Background()
+	    client, _ := storage.NewClient(ctx, option.WithoutAuthentication())
+	    fs = fs.WithClient(client)
+	}
 
-Authentication
+# Authentication
 
 Authentication, by default, occurs automatically when Client() is called. It looks for credentials in the following places,
 preferring the first location found:
 
-  1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable
-  2. A JSON file in a location known to the gcloud command-line tool.
-     On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
-     On other systems, $HOME/.config/gcloud/application_default_credentials.json.
-  3. On Google App Engine it uses the appengine.AccessToken function.
-  4. On Google Compute Engine and Google App Engine Managed VMs, it fetches credentials from the metadata server.
+ 1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable
+ 2. A JSON file in a location known to the gcloud command-line tool.
+    On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
+    On other systems, $HOME/.config/gcloud/application_default_credentials.json.
+ 3. On Google App Engine it uses the appengine.AccessToken function.
+ 4. On Google Compute Engine and Google App Engine Managed VMs, it fetches credentials from the metadata server.
 
 See https://cloud.google.com/docs/authentication/production for more auth info
 
-See Also
+# See Also
 
 See: https://github.com/googleapis/google-cloud-go/tree/master/storage
-
 */
 package gs

--- a/backend/mem/doc.go
+++ b/backend/mem/doc.go
@@ -2,19 +2,22 @@
 Package mem built-in mem lib VFS implementation.
 Usage
 Rely on github.com/c2fo/vfs/v6/backend
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/c2fo/vfs/v6/backend/mem"
-  )
-  func UseFs() error {
-      fs := backend.Backend(mem.Scheme)
-      ...
-  }
+
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/c2fo/vfs/v6/backend/mem"
+	)
+	func UseFs() error {
+	    fs := backend.Backend(mem.Scheme)
+	    ...
+	}
+
 Or call directly:
-  import _mem "github.com/c2fo/vfs/v6/backend/mem"
-  func DoSomething() {
-	fs := _mem.NewFileSystem()
-      ...
-  }
+
+	  import _mem "github.com/c2fo/vfs/v6/backend/mem"
+	  func DoSomething() {
+		fs := _mem.NewFileSystem()
+	      ...
+	  }
 */
 package mem

--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -14,17 +14,15 @@ import (
 	"github.com/c2fo/vfs/v6/utils"
 )
 
-//
-//	memFile with name "filename" is the single representation of the structure that
-//	all calls to "filename" will reference. The point of doing it this way is
-//	to allow multiple read threads, and locking up writing and deletion.
-//	Files referencing filename will check their own 'contents' slice against
-//	"filename's" and is updated accordingly. This allows multiple threads to have the most
-//	up-to-date file contents while also preserving the state of their own cursor that is
-//	used in Read() and Seek() calls. Calls to Write() all reference
-// 	"filename's" buffer, which is why it is locked. Data written into the writeBuffer
-//	does not appear in "filename's" 'contents' slice until a call to Close() is made
-//
+// memFile with name "filename" is the single representation of the structure that
+// all calls to "filename" will reference. The point of doing it this way is
+// to allow multiple read threads, and locking up writing and deletion.
+// Files referencing filename will check their own 'contents' slice against
+// "filename's" and is updated accordingly. This allows multiple threads to have the most
+// up-to-date file contents while also preserving the state of their own cursor that is
+// used in Read() and Seek() calls. Calls to Write() all reference
+// "filename's" buffer, which is why it is locked. Data written into the writeBuffer
+// does not appear in "filename's" 'contents' slice until a call to Close() is made
 type memFile struct {
 	sync.Mutex
 	writeBuffer  *bytes.Buffer
@@ -50,7 +48,7 @@ type File struct {
 
 }
 
-//		////// Error Functions ///////		//
+// ////// Error Functions ///////		//
 func doesNotExist() error {
 	return errors.New("this file does not exist")
 }

--- a/backend/os/doc.go
+++ b/backend/os/doc.go
@@ -1,30 +1,30 @@
 /*
 Package os built-in os lib VFS implementation.
 
-Usage
+# Usage
 
 Rely on github.com/c2fo/vfs/v6/backend
 
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/c2fo/vfs/v6/backend/os"
-  )
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/c2fo/vfs/v6/backend/os"
+	)
 
-  func UseFs() error {
-      fs := backend.Backend(os.Scheme)
-      ...
-  }
+	func UseFs() error {
+	    fs := backend.Backend(os.Scheme)
+	    ...
+	}
 
 Or call directly:
 
-  import _os "github.com/c2fo/vfs/v6/backend/os"
+	import _os "github.com/c2fo/vfs/v6/backend/os"
 
-  func DoSomething() {
-      fs := &_os.FileSystem{}
-      ...
-  }
+	func DoSomething() {
+	    fs := &_os.FileSystem{}
+	    ...
+	}
 
-See Also
+# See Also
 
 See: https://golang.org/pkg/os/
 */

--- a/backend/os/file_test.go
+++ b/backend/os/file_test.go
@@ -718,7 +718,7 @@ func TestOSFile(t *testing.T) {
 }
 
 /*
-	Setup TEST FILES
+Setup TEST FILES
 */
 func setupTestFiles(baseLoc vfs.Location) {
 

--- a/backend/s3/doc.go
+++ b/backend/s3/doc.go
@@ -1,89 +1,91 @@
 /*
 Package s3 AWS S3 VFS implementation.
 
-Usage
+# Usage
 
 Rely on github.com/c2fo/vfs/v6/backend
 
-  import(
-      "github.com/c2fo/vfs/v6/backend"
-      "github.com/c2fo/vfs/v6/backend/s3"
-  )
+	import(
+	    "github.com/c2fo/vfs/v6/backend"
+	    "github.com/c2fo/vfs/v6/backend/s3"
+	)
 
-  func UseFs() error {
-      fs := backend.Backend(s3.Scheme)
-      ...
-  }
+	func UseFs() error {
+	    fs := backend.Backend(s3.Scheme)
+	    ...
+	}
 
 Or call directly:
 
-  import "github.com/c2fo/vfs/v6/backend/s3"
+	import "github.com/c2fo/vfs/v6/backend/s3"
 
-  func DoSomething() {
-      fs := s3.NewFileSystem()
-      ...
-  }
+	func DoSomething() {
+	    fs := s3.NewFileSystem()
+	    ...
+	}
 
 s3 can be augmented with the following implementation-specific methods.  Backend returns vfs.FileSystem interface so it
 would have to be cast as s3.FileSystem to use the following:
 
-  func DoSomething() {
+	func DoSomething() {
 
-      ...
+	    ...
 
-      // cast if fs was created using backend.Backend().  Not necessary if created directly from s3.NewFileSystem().
-      fs = fs.(s3.FileSystem)
+	    // cast if fs was created using backend.Backend().  Not necessary if created directly from s3.NewFileSystem().
+	    fs = fs.(s3.FileSystem)
 
-      // to pass in client options
-      fs = fs.WithOptions(
-          s3.Options{
-              AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
-              SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-              Region:          "us-west-2",
-              ACL: 			   "bucket-owner-full-control",
-          },
-      )
+	    // to pass in client options
+	    fs = fs.WithOptions(
+	        s3.Options{
+	            AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+	            SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	            Region:          "us-west-2",
+	            ACL: 			   "bucket-owner-full-control",
+	        },
+	    )
 
-      // to pass specific client, for instance a mock client
-      s3apiMock := &mocks.S3API{}
-      s3apiMock.On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).
-          Return(&s3.GetObjectOutput{
-              Body: nopCloser{bytes.NewBufferString("Hello world!")},
-              }, nil)
-      fs = fs.WithClient(s3apiMock)
-  }
+	    // to pass specific client, for instance a mock client
+	    s3apiMock := &mocks.S3API{}
+	    s3apiMock.On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).
+	        Return(&s3.GetObjectOutput{
+	            Body: nopCloser{bytes.NewBufferString("Hello world!")},
+	            }, nil)
+	    fs = fs.WithClient(s3apiMock)
+	}
 
-Object ACL
+# Object ACL
 
 Canned ACL's can be passed in as an Option.  This string will be applied to all writes, moves, and copies.
 See https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl for values.
 
-Authentication
+# Authentication
 
 Authentication, by default, occurs automatically when Client() is called. It looks for credentials in the following places,
 preferring the first location found:
 
-  1. StaticProvider - set of credentials which are set programmatically, and will never expire.
-  2. EnvProvider - credentials from the environment variables of the
-     running process. Environment credentials never expire.
-     Environment variables used:
+ 1. StaticProvider - set of credentials which are set programmatically, and will never expire.
 
-  	* Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
-  	* Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
+ 2. EnvProvider - credentials from the environment variables of the
+    running process. Environment credentials never expire.
+    Environment variables used:
 
-  3. SharedCredentialsProvider - looks for "AWS_SHARED_CREDENTIALS_FILE" env variable. If the
-     env value is empty will default to current user's home directory.
+    * Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
+    * Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
 
-  	* Linux/OSX: "$HOME/.aws/credentials"
-  	* Windows:   "%USERPROFILE%\.aws\credentials"
+ 3. SharedCredentialsProvider - looks for "AWS_SHARED_CREDENTIALS_FILE" env variable. If the
+    env value is empty will default to current user's home directory.
 
-  4. RemoteCredProvider - default remote endpoints such as EC2 or ECS IAM Roles
-  5. EC2RoleProvider - credentials from the EC2 service, and keeps track if those credentials are expired
+    * Linux/OSX: "$HOME/.aws/credentials"
+    * Windows:   "%USERPROFILE%\.aws\credentials"
+
+ 4. RemoteCredProvider - default remote endpoints such as EC2 or ECS IAM Roles
+
+ 5. EC2RoleProvider - credentials from the EC2 service, and keeps track if those credentials are expired
 
 See the following for more auth info: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 and https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
 
-See Also
+# See Also
 
 See: https://github.com/aws/aws-sdk-go/tree/master/service/s3
 */

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -347,7 +347,7 @@ func (f *File) String() string {
 }
 
 /*
-	Private helper functions
+Private helper functions
 */
 func (f *File) getAllObjectVersions(client s3iface.S3API) (*s3.ListObjectVersionsOutput, error) {
 	prefix := utils.RemoveLeadingSlash(f.key)

--- a/backend/s3/location_test.go
+++ b/backend/s3/location_test.go
@@ -325,7 +325,7 @@ func TestLocation(t *testing.T) {
 }
 
 /*
-	Helpers
+Helpers
 */
 func convertKeysToS3Objects(keys []string) []*s3.Object {
 	var objects []*s3.Object

--- a/backend/s3/options.go
+++ b/backend/s3/options.go
@@ -104,7 +104,7 @@ func initCredentialProviderChain(opt Options) ([]credentials.Provider, error) {
 	// * Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
 	//
 	// * Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
-	p = append(p, &credentials.EnvProvider{}) // nolint:gocritic // appendCombine
+	p = append(p, &credentials.EnvProvider{}) //nolint:gocritic // appendCombine
 
 	// Path to the shared credentials file.
 	//

--- a/backend/sftp/doc.go
+++ b/backend/sftp/doc.go
@@ -1,33 +1,33 @@
 /*
 Package sftp SFTP VFS implementation.
 
-Usage
+# Usage
 
 Rely on github.com/c2fo/vfs/v6/backend
 
-  import(
-	  "github.com/c2fo/vfs/v6/backend"
-	  "github.com/c2fo/vfs/v6/backend/sftp"
-  )
+	  import(
+		  "github.com/c2fo/vfs/v6/backend"
+		  "github.com/c2fo/vfs/v6/backend/sftp"
+	  )
 
-  func UseFs() error {
-	  fs := backend.Backend(sftp.Scheme)
-	  ...
-  }
+	  func UseFs() error {
+		  fs := backend.Backend(sftp.Scheme)
+		  ...
+	  }
 
 Or call directly:
 
-  import "github.com/c2fo/vfs/v6/backend/sftp"
+	  import "github.com/c2fo/vfs/v6/backend/sftp"
 
-  func DoSomething() {
-	  fs := sftp.NewFilesystem()
+	  func DoSomething() {
+		  fs := sftp.NewFilesystem()
 
-	  location, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
-	  if err != nil {
-		 #handle error
+		  location, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
+		  if err != nil {
+			 #handle error
+		  }
+		  ...
 	  }
-	  ...
-  }
 
 sftp can be augmented with some implementation-specific methods.  Backend returns vfs.Filesystem interface so it
 would have to be cast as sftp.Filesystem to use them.
@@ -36,50 +36,49 @@ These methods are chainable:
 (*FileSystem) WithClient(client interface{}) *FileSystem
 (*FileSystem) WithOptions(opts vfs.Options) *FileSystem
 
+	  func DoSomething() {
 
-  func DoSomething() {
+		  // cast if fs was created using backend.Backend().  Not necessary if created directly from sftp.NewFilesystem().
+		  fs := backend.Backend(sftp.Scheme)
+		  fs = fs.(*sftp.Filesystem)
 
-	  // cast if fs was created using backend.Backend().  Not necessary if created directly from sftp.NewFilesystem().
-	  fs := backend.Backend(sftp.Scheme)
-	  fs = fs.(*sftp.Filesystem)
+		  // to pass specific client
+		  sshClient, err := ssh.Dial("tcp", "myuser@server.com:22", &ssh.ClientConfig{
+			  User:            "someuser",
+			  Auth:            []ssh.AuthMethod{ssh.Password("mypassword")},
+			  HostKeyCallback: ssh.InsecureIgnoreHostKey,
+		  })
+		  #handle error
+		  client, err := _sftp.NewClient(sshClient)
+		  #handle error
 
-	  // to pass specific client
-	  sshClient, err := ssh.Dial("tcp", "myuser@server.com:22", &ssh.ClientConfig{
-		  User:            "someuser",
-		  Auth:            []ssh.AuthMethod{ssh.Password("mypassword")},
-		  HostKeyCallback: ssh.InsecureIgnoreHostKey,
-	  })
-	  #handle error
-	  client, err := _sftp.NewClient(sshClient)
-	  #handle error
+		  fs = fs.WithClient(client)
 
-	  fs = fs.WithClient(client)
+		  // to pass in client options. See Options for more info.  Note that changes to Options will make nil any client.
+		  // This behavior ensures that changes to settings will get applied to a newly created client.
+		  fs = fs.WithOptions(
+			  sftp.Options{
+				  KeyFilePath:   "/home/Bob/.ssh/id_rsa",
+				  KeyPassphrase: "s3cr3t",
+				  KnownHostsCallback: ssh.InsecureIgnoreHostKey,
+			  },
+		  )
 
-	  // to pass in client options. See Options for more info.  Note that changes to Options will make nil any client.
-	  // This behavior ensures that changes to settings will get applied to a newly created client.
-	  fs = fs.WithOptions(
-		  sftp.Options{
-			  KeyFilePath:   "/home/Bob/.ssh/id_rsa",
-			  KeyPassphrase: "s3cr3t",
-			  KnownHostsCallback: ssh.InsecureIgnoreHostKey,
-		  },
-	  )
+		  location, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
+		  #handle error
 
-	  location, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
-	  #handle error
+		  file := location.NewFile("myfile.txt")
+		  #handle error
 
-	  file := location.NewFile("myfile.txt")
-	  #handle error
+		  _, err := file.Write([]bytes("some text")
+		  #handle error
 
-	  _, err := file.Write([]bytes("some text")
-	  #handle error
+		  err := file.Close()
+		  #handle error
 
-	  err := file.Close()
-	  #handle error
+	  }
 
-  }
-
-Authentication
+# Authentication
 
 Authentication, by default, occurs automatically when Client() is called. Since user is part of the URI authority section
 (Volume), auth is handled slightly differently than other vfs backends.
@@ -88,18 +87,18 @@ A client is initialized lazily, meaning we only make a connection to the server 
 options until then.  The authenticated session is closed any time WithOption(), WithClient(), or Close() occurs.  Currently,
 that means that closing a file belonging to an fs will break the connection of any other open file on the same fs.
 
-USERNAME
+# USERNAME
 
 User may only be set in the URI authority section (Volume in vfs parlance).
 
-     scheme             host
-     __/             ___/____  port
-    /  \            /        \ /\
-    sftp://someuser@server.com:22/path/to/file.txt
-           \____________________/ \______________/
-           \______/       \               \
-               /     authority section    path
-         username       (Volume)
+	 scheme             host
+	 __/             ___/____  port
+	/  \            /        \ /\
+	sftp://someuser@server.com:22/path/to/file.txt
+	       \____________________/ \______________/
+	       \______/       \               \
+	           /     authority section    path
+	     username       (Volume)
 
 sftp vfs backend accepts either a password or an ssh key, with or without a passphrase.
 
@@ -114,26 +113,26 @@ Note that as of Go 1.12, OPENSSH private key format is not supported when encryp
 See https://github.com/golang/go/issues/18692
 To force creation of PEM format(instead of OPENSSH format), use `ssh-keygen -m PEM`
 
-KNOWN HOSTS
+# KNOWN HOSTS
 
 Known hosts ensures that the server you're connecting to hasn't been somehow redirected to another server, collecting
 your info (man-in-the-middle attack).  Handling for this can be accomplished via:
-1. Options.KnownHostsString which accepts a string.
-2. Options.KnownHostsFile or environmental variable VFS_SFTP_KNOWN_HOSTS_FILE which accepts a path to a known_hosts file.
-3. Options.KnownHostsCallback which allows you to specify any of the ssh.AuthMethod functions.  Environmental variable
-   VFS_SFTP_INSECURE_KNOWN_HOSTS will set this callback function to ssh.InsecureIgnoreHostKey which may be helpful
-   for testing but should not be used in production.
-4. Defaults to trying to find and use <homedir>/.ssh/known_hosts.  For unix, system-wide location /etc/ssh/.ssh/known hosts is also checked.
-   SSH doesn't exist natively on Windows and each third-party implementation has a different location for known_hosts. Because
-   of this, no attempt is made to find a system-wide file for Windows.  It's better to specify in KnownHostsFile in that case.
+ 1. Options.KnownHostsString which accepts a string.
+ 2. Options.KnownHostsFile or environmental variable VFS_SFTP_KNOWN_HOSTS_FILE which accepts a path to a known_hosts file.
+ 3. Options.KnownHostsCallback which allows you to specify any of the ssh.AuthMethod functions.  Environmental variable
+    VFS_SFTP_INSECURE_KNOWN_HOSTS will set this callback function to ssh.InsecureIgnoreHostKey which may be helpful
+    for testing but should not be used in production.
+ 4. Defaults to trying to find and use <homedir>/.ssh/known_hosts.  For unix, system-wide location /etc/ssh/.ssh/known hosts is also checked.
+    SSH doesn't exist natively on Windows and each third-party implementation has a different location for known_hosts. Because
+    of this, no attempt is made to find a system-wide file for Windows.  It's better to specify in KnownHostsFile in that case.
 
-OTHER OPTIONS
+# OTHER OPTIONS
 
 Passing in multiple key exchange algorithms is supported - these are specified as a slice.
 Example:
 `"keyExchanges":["diffie-hellman-group-a256", "ecdh-sha2-nistp256"]`
 
-AutoDisconnect
+# AutoDisconnect
 
 When dialing a TCP connection, Go doesn't disconnect for you.  This is true even when the connection falls out of scope, and even when
 garbage collection is forced.  The connection must be explicitly closed.  Unfortunately, VFS.FileSystem has no explicit close mechanism.
@@ -176,6 +175,5 @@ should be the most desirable behavior.
 NOTE: AutoDisconnect has nothing to do with "keep alive".  Here we're only concerned with releasing resources, not keeping
 the server from disconnecting us.  If that is something you want, you'd have to implement yourself, injecting your own
 client using WithClient().
-
 */
 package sftp

--- a/backend/sftp/doc.go
+++ b/backend/sftp/doc.go
@@ -122,7 +122,8 @@ your info (man-in-the-middle attack).  Handling for this can be accomplished via
  3. Options.KnownHostsCallback which allows you to specify any of the ssh.AuthMethod functions.  Environmental variable
     VFS_SFTP_INSECURE_KNOWN_HOSTS will set this callback function to ssh.InsecureIgnoreHostKey which may be helpful
     for testing but should not be used in production.
- 4. Defaults to trying to find and use <homedir>/.ssh/known_hosts.  For unix, system-wide location /etc/ssh/.ssh/known hosts is also checked.
+ 4. Defaults to trying to find and use <homedir>/.ssh/known_hosts.
+    For unix, system-wide location /etc/ssh/.ssh/known hosts is also checked.
     SSH doesn't exist natively on Windows and each third-party implementation has a different location for known_hosts. Because
     of this, no attempt is made to find a system-wide file for Windows.  It's better to specify in KnownHostsFile in that case.
 

--- a/backend/testsuite/doc.go
+++ b/backend/testsuite/doc.go
@@ -4,7 +4,6 @@ expected behavior of the interface.  Note you my need to pass additional environ
 You may include in a ; separated list any number of uri's whose scheme implementations will be tested.  Each URI
 will be tested against every other URI for io.* and Move/Copy functions.
 
-
 	VFS_INTEGRATION_LOCATIONS="file:///tmp/vfs_test/;mem://A/path/to/"
 	go test -tags=vfsintegration ./backend/testsuite
 

--- a/doc.go
+++ b/doc.go
@@ -2,16 +2,17 @@
 Package vfs provides a pluggable, extensible, and opinionated set of file system
 functionality for Go across a number of file system types such as os, S3, and GCS.
 
-Philosophy
+# Philosophy
 
 When building our platform, initially we wrote a library that was something to the effect of
-  if config.DISK == "S3" {
-	  // do some s3 file system operation
-  } else if config.DISK == "mock" {
-      // fake something
-  } else {
-      // do some native os.xxx operation
-  }
+
+	  if config.DISK == "S3" {
+		  // do some s3 file system operation
+	  } else if config.DISK == "mock" {
+	      // fake something
+	  } else {
+	      // do some native os.xxx operation
+	  }
 
 Not only was ugly but because the behaviors of each "file system" were different and we had to constantly alter the
 file locations and pass a bucket string (even if the fs didn't know what a bucket was).
@@ -22,38 +23,42 @@ Unfortunately, it didn't support Google Cloud Storage and there was still a lot 
 Few, if any, of the vfs-like libraries provided interfaces to easily and confidently create new file system backends.
 
 What we needed/wanted was the following(and more):
-  * self-contained set of structs that could be passed around like a file/dir handle
-  * the struct would represent an existing or nonexistent file/dir
-  * provide common (and only common) functionality across all file system so that after initialization, we don't care
+  - self-contained set of structs that could be passed around like a file/dir handle
+  - the struct would represent an existing or nonexistent file/dir
+  - provide common (and only common) functionality across all file system so that after initialization, we don't care
     what the underlying file system is and can therefore write our code agnostically/portably
-  * use io.* interfaces such as io.Reader and io.Writer without needing to call a separate function
-  * extensibility to easily add other needed file systems like Microsoft Azure Cloud File Storage or SFTP
-  * prefer native atomic functions when possible (ie S3 to S3 moving would use the native move api call rather than
+  - use io.* interfaces such as io.Reader and io.Writer without needing to call a separate function
+  - extensibility to easily add other needed file systems like Microsoft Azure Cloud File Storage or SFTP
+  - prefer native atomic functions when possible (ie S3 to S3 moving would use the native move api call rather than
     copy-delete)
-  * a uniform way of addressing files regardless of file system.  This is why we use complete URI's in vfssimple
-  * fmt.Stringer interface so that the file struct passed to a log message (or other Stringer use) would show the URI
-  * mockable file system
-  * pluggability so that third-party implementations of our interfaces could be used
+  - a uniform way of addressing files regardless of file system.  This is why we use complete URI's in vfssimple
+  - fmt.Stringer interface so that the file struct passed to a log message (or other Stringer use) would show the URI
+  - mockable file system
+  - pluggability so that third-party implementations of our interfaces could be used
 
-Install
+# Install
 
 Pre 1.17:
-  go get -u github.com/c2fo/vfs/v6
+
+	go get -u github.com/c2fo/vfs/v6
 
 Post 1.17:
-  go install -u github.com/c2fo/vfs/v6
 
+	go install -u github.com/c2fo/vfs/v6
 
-Upgrading
+# Upgrading
 
 Upgrading from v5 to v6
 With v6.0.0, sftp.Options struct changed to accept an array of Key Exchange algorithms rather than a string.
 To update, change the syntax of the auth commands.
-  "keyExchanges":"diffie-hellman-group-a256"
-becomes
-  "keyExchanges":["diffie-hellman-group-a256"]
 
-Usage
+	"keyExchanges":"diffie-hellman-group-a256"
+
+becomes
+
+	"keyExchanges":["diffie-hellman-group-a256"]
+
+# Usage
 
 We provide vfssimple as basic way of initializing file system backends (see each implementations's docs about authentication).
 vfssimple pulls in every c2fo/vfs backend.  If you need to reduce the backend requirements (and app memory footprint) or
@@ -61,53 +66,51 @@ add a third party backend, you'll need to implement your own "factory".  See bac
 
 You can then use those file systems to initialize locations which you'll be referencing frequently, or initialize files directly
 
+	osFile, err := vfssimple.NewFile("file:///path/to/file.txt")
+	s3File, err := vfssimple.NewFile("s3://bucket/prefix/file.txt")
 
-  osFile, err := vfssimple.NewFile("file:///path/to/file.txt")
-  s3File, err := vfssimple.NewFile("s3://bucket/prefix/file.txt")
+	osLocation, err := vfssimple.NewLocation("file:///tmp/")
+	s3Location, err := vfssimple.NewLocation("s3://bucket/")
 
-  osLocation, err := vfssimple.NewLocation("file:///tmp/")
-  s3Location, err := vfssimple.NewLocation("s3://bucket/")
-
-  osTmpFile, err := osLocation.NewFile("anotherFile.txt") // file at /tmp/anotherFile.txt
-
+	osTmpFile, err := osLocation.NewFile("anotherFile.txt") // file at /tmp/anotherFile.txt
 
 You can perform a number of actions without any consideration for the underlying system's api or implementation details.
 
-  osFileExists, err := osFile.Exists() // true, nil
-  s3FileExists, err := s3File.Exists() // false, nil
-  err = osFile.CopyToFile(s3File) // nil
-  s3FileExists, err = s3File.Exists() // true, nil
+	osFileExists, err := osFile.Exists() // true, nil
+	s3FileExists, err := s3File.Exists() // false, nil
+	err = osFile.CopyToFile(s3File) // nil
+	s3FileExists, err = s3File.Exists() // true, nil
 
-  movedOsFile, err := osFile.MoveToLocation(osLocation)
-  osFileExists, err = osFile.Exists() // false, nil (move actions delete the original file)
-  movedOsFileExists, err := movedOsFile.Exists() // true, nil
+	movedOsFile, err := osFile.MoveToLocation(osLocation)
+	osFileExists, err = osFile.Exists() // false, nil (move actions delete the original file)
+	movedOsFileExists, err := movedOsFile.Exists() // true, nil
 
-  s3FileUri := s3File.URI() // s3://bucket/prefix/file.txt
-  s3FileName := s3File.Name() // file.txt
-  s3FilePath := s3File.Path() // /prefix/file.txt
+	s3FileUri := s3File.URI() // s3://bucket/prefix/file.txt
+	s3FileName := s3File.Name() // file.txt
+	s3FilePath := s3File.Path() // /prefix/file.txt
 
 File's io.* interfaces may be used directly:
 
-  reader := strings.NewReader("Clear is better than clever")
-  gsFile, err := vfssimple.NewFile("gs://somebucket/path/to/file.txt")
+	reader := strings.NewReader("Clear is better than clever")
+	gsFile, err := vfssimple.NewFile("gs://somebucket/path/to/file.txt")
 
-  byteCount, err := io.Copy(gsFile, reader)
-  err := gsFile.Close()
+	byteCount, err := io.Copy(gsFile, reader)
+	err := gsFile.Close()
 
-Third-party Backends
+# Third-party Backends
 
 * none so far
 
 Feel free to send a pull request if you want to add your backend to the list.
 
-Ideas
+# Ideas
 
 Things to add:
-  * Add Azure storage backend
-  * Provide better List() functionality with more abstracted filtering and paging (iterator?) Return File structs vs URIs?
-  * Add better/any context.Context() support
+  - Add Azure storage backend
+  - Provide better List() functionality with more abstracted filtering and paging (iterator?) Return File structs vs URIs?
+  - Add better/any context.Context() support
 
-Contributors
+# Contributors
 
 Brought to you by the Enterprise Pipeline team at C2FO:
 
@@ -120,17 +123,17 @@ https://github.com/c2fo/
 
 Contributing
 
-  1. Fork it (<https://github.com/c2fo/vfs/fork>)
-  2. Create your feature branch (`git checkout -b feature/fooBar`)
-  3. Commit your changes (`git commit -am 'Add some fooBar'`)
-  4. Push to the branch (`git push origin feature/fooBar`)
-  5. Create a new Pull Request
+ 1. Fork it (<https://github.com/c2fo/vfs/fork>)
+ 2. Create your feature branch (`git checkout -b feature/fooBar`)
+ 3. Commit your changes (`git commit -am 'Add some fooBar'`)
+ 4. Push to the branch (`git push origin feature/fooBar`)
+ 5. Create a new Pull Request
 
-License
+# License
 
 Distributed under the MIT license. See `http://github.com/c2fo/vfs/License.md for more information.
 
-Definitions
+# Definitions
 
 * absolute path - A path is said to be absolute if it provides the entire context need to find a file, including the
 file system root. An absolute path must begin with a slash and may include . and .. directories.

--- a/options/options.go
+++ b/options/options.go
@@ -3,13 +3,15 @@ package options
 // DeleteOption interface contains function that should be implemented by any custom option to qualify as a delete option.
 // Example:
 // ```
+//
 //	type TakeBackupDeleteOption{}
-// 	func (o TakeBackupDeleteOption) DeleteOptionName() string {
+//	func (o TakeBackupDeleteOption) DeleteOptionName() string {
 //		return "take backup"
 //	}
 //	func (o TakeBackupDeleteOption) BackupLocation() string {
-// 		return o.backupLocation
+//		return o.backupLocation
 //	}
+//
 // ```
 type DeleteOption interface {
 	DeleteOptionName() string

--- a/utils/authority.go
+++ b/utils/authority.go
@@ -14,8 +14,9 @@ type Authority struct {
 
 // String() returns a string representation of authority.  It does not include password per
 // https://tools.ietf.org/html/rfc3986#section-3.2.1:
-//   Applications should not render as clear text any data after the first colon (":") character found within a userinfo
-//   subcomponent unless the data after the colon is the empty string (indicating no password).
+//
+//	Applications should not render as clear text any data after the first colon (":") character found within a userinfo
+//	subcomponent unless the data after the colon is the empty string (indicating no password).
 func (a Authority) String() string {
 	if a.User != "" {
 		return fmt.Sprintf("%s@%s", a.User, a.Host)

--- a/vfs.go
+++ b/vfs.go
@@ -231,13 +231,14 @@ type Options interface{}
 // is called by the underlying VFS implementation.
 //
 // Ex:
-//   var retrier Retry = func(wrapped func() error) error {
-//     var ret error
-//     for i := 0; i < 5; i++ {
-//        if err := wrapped(); err != nil { ret = err; continue }
-//     }
-//     return ret
-//   }
+//
+//	var retrier Retry = func(wrapped func() error) error {
+//	  var ret error
+//	  for i := 0; i < 5; i++ {
+//	     if err := wrapped(); err != nil { ret = err; continue }
+//	  }
+//	  return ret
+//	}
 type Retry func(wrapped func() error) error
 
 // DefaultRetryer returns a no-op retryer which simply calls the wrapped command without looping.

--- a/vfscp/doc.go
+++ b/vfscp/doc.go
@@ -3,21 +3,25 @@ vfscp copies a file from one place to another, even between supported remote sys
 Complete URI (scheme:// authority/path) required except for local file system.
 See github.com/c2fo/vfs docs for authentication.
 
-
-Usage
+# Usage
 
 vfscp's usage is extremely simple:
 
-  vfscp <uri> <uri>
-  -help   prints help message
+	vfscp <uri> <uri>
+	-help   prints help message
 
-Examples
+# Examples
 
 Local OS URI's can be expressed without a scheme:
-  vfscp /some/local/file.txt s3://mybucket/path/to/myfile.txt
+
+	vfscp /some/local/file.txt s3://mybucket/path/to/myfile.txt
+
 But may also be use the full scheme uri:
-  vfscp file:///some/local/file.txt s3://mybucket/path/to/myfile.txt
+
+	vfscp file:///some/local/file.txt s3://mybucket/path/to/myfile.txt
+
 Copy a file from Google Cloud Storage to Amazon S3
-  vfscp gs://googlebucket/some/path/photo.jpg s3://awsS3bucket/path/to/photo.jpg
+
+	vfscp gs://googlebucket/some/path/photo.jpg s3://awsS3bucket/path/to/photo.jpg
 */
 package main

--- a/vfssimple/doc.go
+++ b/vfssimple/doc.go
@@ -1,10 +1,10 @@
 /*
 Package vfssimple provides a basic and easy to use set of functions to any supported backend file system by using full URI's:
-  * Local OS:             file:///some/path/to/file.txt
-  * Amazon S3:            s3://mybucket/path/to/file.txt
-  * Google Cloud Storage: gs://mybucket/path/to/file.txt
+  - Local OS:             file:///some/path/to/file.txt
+  - Amazon S3:            s3://mybucket/path/to/file.txt
+  - Google Cloud Storage: gs://mybucket/path/to/file.txt
 
-Usage
+# Usage
 
 Just import vfssimple.
 
@@ -35,7 +35,7 @@ Just import vfssimple.
 		fmt.Printf("moved %s to %s\n", myS3File, localFile)
 	}
 
-Authentication and Options
+# Authentication and Options
 
 vfssimple is largely an example of how to initialize a set of backend file systems.  It only provides a default
 initialization of the individual file systems.  See backend docs for specific authentication info for each backend but
@@ -80,7 +80,7 @@ file system.
 		fmt.Printf("copied %s to %s\n", secureFile, publicLocation)
 	}
 
-Registered Backend Resolution
+# Registered Backend Resolution
 
 Every backend type automatically registers itself as an available backend filesystem for vfssimple based on its scheme.  In this way,
 vfssimple is able to determine which backend to use for any related URI.  As mentioned above, you can register your own initialized
@@ -110,6 +110,5 @@ See the expected registered bucket name for each:
 	's3'                         - URI: 's3://other/'                        (scheme-level match, only)
 	's3'                         - URI: 's3://other/file.txt'                (scheme-level match, only)
 	's3'                         - URI: 's3://other/path/to/nowhere/'        (scheme-level match, only)
-
 */
 package vfssimple


### PR DESCRIPTION
I ran `gofmt -s -w .` to get the **golangci-lint / lint** workflow to pass.