### PR TITLE
Stream on read 145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Fixed
+- fixed #145 - Remove use of local temp file when reading/seeking from s3 files.  This should improve performance by allowing streaming reads from s3 files.
 
 ## [6.9.1] - 2023-11-21
 ### Fixed

--- a/backend/helpers.go
+++ b/backend/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/c2fo/vfs/v6"
 )
 
-// ValidateCopySeekPosition return ensures curren seek cursor is 0,0. This is useful to ensure it's safe to copy.  A seek position
+// ValidateCopySeekPosition return ensures current seek cursor is 0,0. This is useful to ensure it's safe to copy.  A seek position
 // elsewhere will mean a partial copy.
 func ValidateCopySeekPosition(f vfs.File) error {
 	// validate seek is at 0,0 before doing copy

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -341,14 +341,13 @@ func (f *File) Write(data []byte) (res int, err error) {
 		f.writeBuffer = bytes.NewBuffer([]byte{})
 	}
 
-	write, err := f.writeBuffer.Write(data)
+	written, err := f.writeBuffer.Write(data)
 	if err != nil {
 		return 0, err
 	}
-	offset := int64(write)
-	f.cursorPos += offset
+	f.cursorPos += int64(written)
 
-	return write, err
+	return written, err
 }
 
 // Touch creates a zero-length file on the vfs.File if no File exists.  Update File's last modified timestamp.

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -480,10 +480,6 @@ func (f *File) getCopyObjectInput(targetFile *File) (*s3.CopyObjectInput, error)
 	return nil, nil
 }
 
-func (f *File) getObjectInput() *s3.GetObjectInput {
-	return new(s3.GetObjectInput).SetBucket(f.bucket).SetKey(f.key)
-}
-
 // TODO: need to provide an implementation-agnostic container for providing config options such as SSE
 func uploadInput(f *File) *s3manager.UploadInput {
 	sseType := "AES256"

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -2,10 +2,10 @@ package s3
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"path"
 	"time"
 
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 
 	"github.com/c2fo/vfs/v6"
-	"github.com/c2fo/vfs/v6/backend"
 	"github.com/c2fo/vfs/v6/mocks"
 	"github.com/c2fo/vfs/v6/options"
 	"github.com/c2fo/vfs/v6/options/delete"
@@ -28,7 +27,8 @@ type File struct {
 	fileSystem  *FileSystem
 	bucket      string
 	key         string
-	tempFile    *os.File
+	cursorPos   int64
+	reader      io.ReadCloser
 	writeBuffer *bytes.Buffer
 }
 
@@ -104,8 +104,8 @@ func (f *File) Location() vfs.Location {
 // method if the target file is also on S3, otherwise uses io.CopyBuffer.
 func (f *File) CopyToFile(file vfs.File) error {
 	// validate seek is at 0,0 before doing copy
-	if err := backend.ValidateCopySeekPosition(f); err != nil {
-		return err
+	if f.cursorPos != 0 {
+		return vfs.CopyToNotPossible
 	}
 
 	// if target is S3
@@ -235,18 +235,16 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 // Close cleans up underlying mechanisms for reading from and writing to the file. Closes and removes the
 // local temp file, and triggers a write to s3 of anything in the f.writeBuffer if it has been created.
 func (f *File) Close() error {
-	if f.tempFile != nil {
-		err := f.tempFile.Close()
+	f.cursorPos = 0
+
+	// invalidate reader
+	if f.reader != nil {
+		err := f.reader.Close()
 		if err != nil {
 			return err
 		}
 
-		err = os.Remove(f.tempFile.Name())
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-
-		f.tempFile = nil
+		f.reader = nil
 	}
 
 	if f.writeBuffer != nil {
@@ -273,19 +271,65 @@ func (f *File) Close() error {
 // Read implements the standard for io.Reader. For this to work with an s3 file, a temporary local copy of
 // the file is created, and reads work on that. This file is closed and removed upon calling f.Close()
 func (f *File) Read(p []byte) (n int, err error) {
-	if err := f.checkTempFile(); err != nil {
-		return 0, err
+	// check/initialize for reader
+	r, err := f.getReader()
+
+	read, err := r.Read(p)
+	if err != nil {
+		return read, err
 	}
-	return f.tempFile.Read(p)
+
+	f.cursorPos += int64(read)
+
+	return read, nil
 }
 
 // Seek implements the standard for io.Seeker. A temporary local copy of the s3 file is created (the same
 // one used for Reads) which Seek() acts on. This file is closed and removed upon calling f.Close()
 func (f *File) Seek(offset int64, whence int) (int64, error) {
-	if err := f.checkTempFile(); err != nil {
-		return 0, err
+	length, err := f.Size()
+	if err != nil {
+		return 0, handleExistsError(err)
 	}
-	return f.tempFile.Seek(offset, whence)
+
+	seekErr := fmt.Errorf("seek: %s invalid argument", f.URI())
+
+	switch whence {
+	case 0:
+		// cannot seek past beginning of file
+		if offset < 0 {
+			return 0, seekErr
+		}
+
+		f.cursorPos = offset
+	case 1:
+		// cannot seek past beginning of file
+		if f.cursorPos+offset < 0 {
+			return 0, seekErr
+		}
+
+		f.cursorPos += offset
+
+	case 2:
+		// cannot seek past beginning of file
+		if int64(length)+offset < 0 {
+			return 0, seekErr
+		}
+
+		f.cursorPos = int64(length) + offset
+	}
+
+	// invalidate reader
+	if f.reader != nil {
+		err := f.reader.Close()
+		if err != nil {
+			return 0, err
+		}
+
+		f.reader = nil
+	}
+
+	return f.cursorPos, nil
 }
 
 // Write implements the standard for io.Writer. A buffer is added to with each subsequent
@@ -305,7 +349,15 @@ func (f *File) Write(data []byte) (res int, err error) {
 
 		f.writeBuffer = bytes.NewBuffer([]byte{})
 	}
-	return f.writeBuffer.Write(data)
+
+	write, err := f.writeBuffer.Write(data)
+	if err != nil {
+		return 0, err
+	}
+	offset := int64(write)
+	f.cursorPos += offset
+
+	return write, err
 }
 
 // Touch creates a zero-length file on the vfs.File if no File exists.  Update File's last modified timestamp.
@@ -424,48 +476,6 @@ func (f *File) getCopyObjectInput(targetFile *File) (*s3.CopyObjectInput, error)
 	return nil, nil
 }
 
-func (f *File) checkTempFile() error {
-	if f.tempFile == nil {
-		localTempFile, err := f.copyToLocalTempReader()
-		if err != nil {
-			return err
-		}
-		f.tempFile = localTempFile
-	}
-
-	return nil
-}
-
-func (f *File) copyToLocalTempReader() (*os.File, error) {
-	// Create temp file
-	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.%d", f.Name(), time.Now().UnixNano()))
-	if err != nil {
-		return nil, err
-	}
-
-	// Create S3 Downloader, get client, and set partition size for multipart download
-	var partSize int64
-	if opts, ok := f.Location().FileSystem().(*FileSystem).options.(Options); ok {
-		if partSize = opts.DownloadPartitionSize; partSize == 0 {
-			partSize = 32 * 1024 * 1024 // 32 MB per partition default if opts.DownloadPartitionSize is 0
-		}
-	}
-
-	client, err := f.fileSystem.Client()
-	if err != nil {
-		return nil, err
-	}
-
-	// Download file
-	_, err = getDownloader(client, partSize).Download(tmpFile, f.getObjectInput())
-	if err != nil {
-		return nil, err
-	}
-
-	// Return temp file
-	return tmpFile, nil
-}
-
 func (f *File) getObjectInput() *s3.GetObjectInput {
 	return new(s3.GetObjectInput).SetBucket(f.bucket).SetKey(f.key)
 }
@@ -534,8 +544,42 @@ func waitUntilFileExists(file vfs.File, retries int) error {
 	return nil
 }
 
-var getDownloader = func(client s3iface.S3API, partSize int64) Downloader {
-	return s3manager.NewDownloaderWithClient(client, func(d *s3manager.Downloader) {
-		d.PartSize = partSize
-	})
+func (f *File) getReader() (io.ReadCloser, error) {
+	if f.reader == nil {
+		// Create the request to get the object
+		input := new(s3.GetObjectInput).
+			SetBucket(f.bucket).
+			SetKey(f.key).
+			SetRange(fmt.Sprintf("bytes=%d-", f.cursorPos))
+
+		// Get the client
+		client, err := f.fileSystem.Client()
+		if err != nil {
+			return nil, err
+		}
+
+		// Request the object
+		result, err := client.GetObject(input)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the reader to the body of the object
+		f.reader = result.Body
+	}
+	return f.reader, nil
+}
+
+func handleExistsError(err error) error {
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			switch awsErr.Code() {
+			case s3.ErrCodeNoSuchKey, s3.ErrCodeNoSuchBucket, "NotFound":
+				return vfs.ErrNotExist
+			}
+		}
+		return err
+	}
+	return nil
 }

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -98,84 +98,7 @@ func (ts *fileTestSuite) TestWrite() {
 	ts.Nil(err, "Error should be nil when calling Write")
 }
 
-// func (ts *fileTestSuite) TestSeek() {
-// 	contents := "hello world!"
-// 	file, err := fs.NewFile("bucket", "/tmp/hello.txt")
-// 	ts.NoError(err, "Shouldn't fail creating new file")
-//
-// 	// setup mock for Size(getHeadObject)
-// 	headOutput := &s3.HeadObjectOutput{
-// 		ContentLength: aws.Int64(12),
-// 	}
-// 	s3apiMock.
-// 		On("HeadObject", mock.AnythingOfType("*s3.HeadObjectInput")).
-// 		Return(headOutput, nil).
-// 		Times(4)
-//
-// 	// test seek to 6,0
-// 	pos, err := file.Seek(6, 0)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal(int64(6), pos, "Seeking to 6 should return 6 as expected")
-//
-// 	var localFile = bytes.NewBuffer([]byte{})
-//
-// 	s3apiMock.
-// 		On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).
-// 		Return(&s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader("world!"))}, nil).
-// 		Once()
-// 	_, err = io.Copy(localFile, file)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal("world!", localFile.String(), "Seeking should download the file and move the cursor as expected")
-//
-// 	// test seek back to 0,0
-// 	localFile = bytes.NewBuffer([]byte{})
-// 	pos, err = file.Seek(0, 0)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal(int64(0), pos, "Seeking to 0 should return 0 as expected")
-//
-// 	s3apiMock.
-// 		On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).
-// 		Return(&s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(contents))}, nil).
-// 		Once()
-// 	_, err = io.Copy(localFile, file)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal(contents, localFile.String(), "Subsequent calls to seek work on temp file as expected")
-//
-// 	// test seek to 3,1
-// 	localFile = bytes.NewBuffer([]byte{})
-// 	pos, err = file.Seek(6, 0)
-// 	ts.NoError(err, "no error expected")
-// 	pos, err = file.Seek(3, 1)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal(int64(12), pos, "Seeking to 12 should return 12 as expected")
-//
-// 	s3apiMock.
-// 		On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).
-// 		Return(&s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(""))}, nil).
-// 		Once()
-// 	_, err = io.Copy(localFile, file)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal("", localFile.String(), "Seeking to current position should return empty string")
-//
-// 	// test seek to 0,2
-// 	localFile = bytes.NewBuffer([]byte{})
-// 	pos, err = file.Seek(0, 2)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal(int64(12), pos, "Seeking to 12 should return 12 as expected")
-//
-// 	s3apiMock.
-// 		On("GetObject", mock.AnythingOfType("*s3.GetObjectInput")).
-// 		Return(&s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(""))}, nil).
-// 		Once()
-// 	_, err = io.Copy(localFile, file)
-// 	ts.NoError(err, "no error expected")
-// 	ts.Equal("", localFile.String(), "Seeking to end of file should return empty string")
-//
-// 	err = file.Close()
-// 	ts.NoError(err, "no error expected")
-// }
-
-func (ts *fileTestSuite) TestSeek2() {
+func (ts *fileTestSuite) TestSeek() {
 	contents := "hello world!"
 	file, err := fs.NewFile("bucket", "/tmp/hello.txt")
 	ts.NoError(err, "Shouldn't fail creating new file")
@@ -194,6 +117,7 @@ func (ts *fileTestSuite) TestSeek2() {
 		{0, 0, 0, false, contents},
 		{0, 2, 12, false, ""},
 		{-1, 0, 0, true, ""}, // Seek before start
+		{0, 3, 0, true, ""},  // bad whence
 	}
 
 	for _, tc := range testCases {

--- a/errors.go
+++ b/errors.go
@@ -6,8 +6,16 @@ type Error string
 // Error returns a string representation of the error
 func (e Error) Error() string { return string(e) }
 
-// CopyToNotPossible - CopyTo/MoveTo operations are only possible when seek position is 0,0
-const CopyToNotPossible = Error("current cursor offset is not 0 as required for this operation")
-const ErrNotExist = Error("file does not exist")
-const ErrSeekInvalidOffset = Error("seek: invalid offset")
-const ErrSeekInvalidWhence = Error("seek: invalid whence")
+const (
+	// CopyToNotPossible - CopyTo/MoveTo operations are only possible when seek position is 0,0
+	CopyToNotPossible = Error("current cursor offset is not 0 as required for this operation")
+
+	// ErrNotExist - File does not exist
+	ErrNotExist = Error("file does not exist")
+
+	// ErrSeekInvalidOffset - Offset is invalid. Must be greater than or equal to 0
+	ErrSeekInvalidOffset = Error("seek: invalid offset")
+
+	// ErrSeekInvalidWhence - Whence is invalid.  Must be one of the following: 0 (io.SeekStart), 1 (io.SeekCurrent), or 2 (io.SeekEnd)
+	ErrSeekInvalidWhence = Error("seek: invalid whence")
+)

--- a/errors.go
+++ b/errors.go
@@ -8,3 +8,4 @@ func (e Error) Error() string { return string(e) }
 
 // CopyToNotPossible - CopyTo/MoveTo operations are only possible when seek position is 0,0
 const CopyToNotPossible = Error("current cursor offset is not 0 as required for this operation")
+const ErrNotExist = Error("file does not exist")

--- a/errors.go
+++ b/errors.go
@@ -9,3 +9,5 @@ func (e Error) Error() string { return string(e) }
 // CopyToNotPossible - CopyTo/MoveTo operations are only possible when seek position is 0,0
 const CopyToNotPossible = Error("current cursor offset is not 0 as required for this operation")
 const ErrNotExist = Error("file does not exist")
+const ErrSeekInvalidOffset = Error("seek: invalid offset")
+const ErrSeekInvalidWhence = Error("seek: invalid whence")


### PR DESCRIPTION
fixes #145 - Remove use of local temp file when reading/seeking from s3 files.  This should improve performance by allowing streaming reads from s3 files.