### PR TITLE
ensure readEOFSeen reset after reseting cursor with Seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.22.0] - 2024-11-06
 ### Fixed
 - [#214](https://github.com/C2FO/vfs/issues/214) Fix issue where s3 backend didn't reset `readEOFSeen` flag when resetting the file cursor during Seek operations.
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- [#214](https://github.com/C2FO/vfs/issues/214) Fix issue where s3 backend didn't reset `readEOFSeen` flag when resetting the file cursor during Seek operations.
+ 
 ## [6.21.0] - 2024-11-04
 ### Fixed
 - Unit Test improvements: report underlying unit tests errors, always run test cases in a sub-test, always use test suite functions, use more specific assert functions where possible.

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -456,6 +456,11 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 	}
 	f.cursorPos = pos
 
+	// Reset readEOFSeen if seeking to the beginning of the file
+	if f.cursorPos == 0 {
+		f.readEOFSeen = false
+	}
+
 	f.seekCalled = true
 	return f.cursorPos, nil
 }


### PR DESCRIPTION
This is to to fix the bug reported here https://github.com/C2FO/vfs/issues/214 where Seek was not resetting the readEOFSeen when the cursor was being reset. 