### PR TITLE
Azure az:// scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v7.0.0-pre2] - 2025-03-08
+## [v7.0.0-pre3] - 2025-03-09
+### Changed
+- Azure backend now uses the schema `az://` instead of `https://`. *Breaking Change*
+- Azure backend authority is now the blob container name, rather than host + container name. See [README.md](README.md#azure-backend). *Breaking Change*
 
+## [v7.0.0-pre2] - 2025-03-08
 ### Fixed
 - Fixed go.mod and paths to reflect v7
 
 ## [v7.0.0-pre1] - 2025-03-07
-
 ### Changed
 - S3 backend now returns an s3.Client instead of an s3iface.ClientAPI. *Breaking Change*
 - S3 backend s3.Option.Retry field is now an aws.Retryer instead of a (aws) request.Retry. *Breaking Change*

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The project now uses the `aws-sdk-go-v2` library instead of the deprecated, EOL 
 - The S3 backend's s3fs.Client() function now returns an `s3.Client` which is a subset of AWS's sdk v2 functionality. This change may require updates to your code if you were relying client functionality not directly required by the s3 vfs backend.
 - The `Option.Retry` field is now an `aws.Retryer` instead of a `request.Retry`. Ensure that your Option logic is compatible with the new type.
 
+##### Azure Backend
+- Scheme for Azure has been updated from `https` to `az`.  Update your code to use the new scheme.
+- Authority for Azure has been updated from `blob.core.windows.net` to `<blob-container-name>`, such that the full URI is `az://<blob-container-name>/path/to/file.txt` rather than `https://<storage-account-name>.core.windows.net/<blob-container-name>/path/to/file.txt`.
 #### Upgrading from v5 to v6
 With v6.0.0, sftp.Options struct changed to accept an array of Key Exchange algorithms rather than a string. To update, change the syntax of the auth commands.
 ```

--- a/backend/azure/client.go
+++ b/backend/azure/client.go
@@ -3,7 +3,9 @@ package azure
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"time"
 
@@ -51,6 +53,7 @@ type Client interface {
 
 // DefaultClient is the main implementation that actually makes the calls to Azure Blob Storage
 type DefaultClient struct {
+	serviceURL *url.URL
 	credential any
 }
 
@@ -61,10 +64,25 @@ func NewClient(options *Options) (*DefaultClient, error) {
 		return nil, err
 	}
 
-	return &DefaultClient{credential}, nil
+	serviceURL := options.ServiceURL
+	if serviceURL == "" {
+		if options.AccountName == "" {
+			serviceURL = "https://blob.core.windows.net"
+		} else {
+			serviceURL = fmt.Sprintf("https://%s.blob.core.windows.net", options.AccountName)
+		}
+	}
+	u, err := url.Parse(serviceURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DefaultClient{serviceURL: u, credential: credential}, nil
 }
 
 func (a *DefaultClient) newContainerClient(containerURL string) (*container.Client, error) {
+	containerURL = a.serviceURL.JoinPath(containerURL).String()
+
 	switch cred := a.credential.(type) {
 	case azcore.TokenCredential:
 		return container.NewClient(containerURL, cred, nil)
@@ -102,7 +120,7 @@ func (a *DefaultClient) Properties(containerURI, filePath string) (*BlobProperti
 
 // Upload uploads a new file to Azure Blob Storage
 func (a *DefaultClient) Upload(file vfs.File, content io.ReadSeeker, contentType string) error {
-	cli, err := a.newContainerClient(file.Location().(*Location).ContainerURL())
+	cli, err := a.newContainerClient(file.Location().(*Location).container)
 	if err != nil {
 		return err
 	}
@@ -123,7 +141,7 @@ func (a *DefaultClient) Upload(file vfs.File, content io.ReadSeeker, contentType
 
 // SetMetadata sets the given metadata for the blob
 func (a *DefaultClient) SetMetadata(file vfs.File, metadata map[string]*string) error {
-	cli, err := a.newContainerClient(file.Location().(*Location).ContainerURL())
+	cli, err := a.newContainerClient(file.Location().(*Location).container)
 	if err != nil {
 		return err
 	}
@@ -134,7 +152,7 @@ func (a *DefaultClient) SetMetadata(file vfs.File, metadata map[string]*string) 
 
 // Download returns an io.ReadCloser for the given vfs.File
 func (a *DefaultClient) Download(file vfs.File) (io.ReadCloser, error) {
-	cli, err := a.newContainerClient(file.Location().(*Location).ContainerURL())
+	cli, err := a.newContainerClient(file.Location().(*Location).container)
 	if err != nil {
 		return nil, err
 	}
@@ -151,9 +169,10 @@ func (a *DefaultClient) Download(file vfs.File) (io.ReadCloser, error) {
 // error.
 func (a *DefaultClient) Copy(srcFile, tgtFile vfs.File) error {
 	// Can't use url.PathEscape here since that will escape everything (even the directory separators)
-	srcURL := strings.Replace(srcFile.URI(), "%", "%25", -1)
+	srcURL := strings.Replace(srcFile.Path(), "%", "%25", -1)
+	srcURL = a.serviceURL.JoinPath(srcFile.Location().(*Location).container, srcURL).String()
 
-	tgtURL := tgtFile.Location().(*Location).ContainerURL()
+	tgtURL := tgtFile.Location().(*Location).container
 
 	cli, err := a.newContainerClient(tgtURL)
 	if err != nil {
@@ -180,7 +199,7 @@ func (a *DefaultClient) Copy(srcFile, tgtFile vfs.File) error {
 // List will return a listing of the contents of the given location.  Each item in the list will contain the full key
 // as specified by the azure blob (including the virtual 'path').
 func (a *DefaultClient) List(l vfs.Location) ([]string, error) {
-	cli, err := a.newContainerClient(l.(*Location).ContainerURL())
+	cli, err := a.newContainerClient(l.(*Location).container)
 	if err != nil {
 		return []string{}, err
 	}
@@ -206,7 +225,7 @@ func (a *DefaultClient) List(l vfs.Location) ([]string, error) {
 
 // Delete deletes the given file from Azure Blob Storage.
 func (a *DefaultClient) Delete(file vfs.File) error {
-	cli, err := a.newContainerClient(file.Location().(*Location).ContainerURL())
+	cli, err := a.newContainerClient(file.Location().(*Location).container)
 	if err != nil {
 		return err
 	}
@@ -220,7 +239,7 @@ func (a *DefaultClient) Delete(file vfs.File) error {
 // If soft deletion is enabled for blobs in the storage account, each version will be marked for deletion and will be
 // permanently deleted by Azure as per the soft deletion policy.
 func (a *DefaultClient) DeleteAllVersions(file vfs.File) error {
-	cli, err := a.newContainerClient(file.Location().(*Location).ContainerURL())
+	cli, err := a.newContainerClient(file.Location().(*Location).container)
 	if err != nil {
 		return err
 	}

--- a/backend/azure/file.go
+++ b/backend/azure/file.go
@@ -130,7 +130,7 @@ func (f *File) Exists() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	_, err = client.Properties(f.Location().(*Location).ContainerURL(), f.Path())
+	_, err = client.Properties(f.Location().(*Location).container, f.Path())
 	if err != nil {
 		if !bloberror.HasCode(err, bloberror.BlobNotFound) {
 			return false, err
@@ -276,7 +276,7 @@ func (f *File) LastModified() (*time.Time, error) {
 	if err != nil {
 		return nil, err
 	}
-	props, err := client.Properties(f.Location().(*Location).ContainerURL(), f.Path())
+	props, err := client.Properties(f.Location().(*Location).container, f.Path())
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +289,7 @@ func (f *File) Size() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	props, err := client.Properties(f.Location().(*Location).ContainerURL(), f.Path())
+	props, err := client.Properties(f.Location().(*Location).container, f.Path())
 	if err != nil {
 		return 0, err
 	}
@@ -332,7 +332,7 @@ func (f *File) Touch() error {
 		return client.Upload(f, strings.NewReader(""), contentType)
 	}
 
-	props, err := client.Properties(f.Location().(*Location).ContainerURL(), f.Path())
+	props, err := client.Properties(f.Location().(*Location).container, f.Path())
 	if err != nil {
 		return err
 	}
@@ -350,9 +350,9 @@ func (f *File) Touch() error {
 	return nil
 }
 
-// URI returns a full Azure URI for the file
+// URI returns the File's URI as a string.
 func (f *File) URI() string {
-	return fmt.Sprintf("%s://%s%s", f.fileSystem.Scheme(), utils.EnsureTrailingSlash(f.fileSystem.Host()), path.Join(f.container, f.name))
+	return utils.GetFileURI(f)
 }
 
 func (f *File) checkTempFile() error {

--- a/backend/azure/file.go
+++ b/backend/azure/file.go
@@ -30,7 +30,7 @@ type File struct {
 	isDirty    bool
 }
 
-// Close cleans up all of the backing data structures used for reading/writing files.  This includes, closing the
+// Close cleans up all the backing data structures used for reading/writing files.  This includes, closing the
 // temp file, uploading the contents of the temp file to Azure Blob Storage (if necessary), and calling Seek(0, 0).
 func (f *File) Close() error {
 	if f.tempFile != nil {

--- a/backend/azure/fileSystem.go
+++ b/backend/azure/fileSystem.go
@@ -2,11 +2,7 @@ package azure
 
 import (
 	"errors"
-	"fmt"
-	"net/url"
 	"path"
-	"regexp"
-	"strings"
 
 	"github.com/c2fo/vfs/v7"
 	"github.com/c2fo/vfs/v7/backend"
@@ -15,7 +11,7 @@ import (
 )
 
 // Scheme defines the scheme for the azure implementation
-const Scheme = "https"
+const Scheme = "az"
 
 // Name defines the name for the azure implementation
 const Name = "azure"
@@ -105,14 +101,9 @@ func (fs *FileSystem) Name() string {
 	return Name
 }
 
-// Scheme returns "https" as the initial part of the URI i.e. https://..
+// Scheme returns "az" as the initial part of the URI i.e. https://..
 func (fs *FileSystem) Scheme() string {
 	return Scheme
-}
-
-// Host returns the host portion of the URI.  For azure this consists of <account_name>.blob.core.windows.net.
-func (fs *FileSystem) Host() string {
-	return fmt.Sprintf("%s.blob.core.windows.net", fs.options.AccountName)
 }
 
 // Retry returns the default retry function.  This is overridable via the WithOptions function.
@@ -126,29 +117,4 @@ func (fs *FileSystem) Retry() vfs.Retry {
 func init() {
 	// registers a default FileSystem
 	backend.Register(Scheme, NewFileSystem())
-}
-
-// ParsePath is a utility function used by vfssimple to separate the host from the path.  The first parameter returned
-// is the host and the second parameter is the path.
-func ParsePath(p string) (host, pth string, err error) {
-	if p == "/" {
-		return "", "", errors.New("no container specified for Azure path")
-	}
-	isLocation := strings.HasSuffix(p, "/")
-	l := strings.Split(p, "/")
-	p = utils.EnsureLeadingSlash(path.Join(l[2:]...))
-	if isLocation {
-		p = utils.EnsureTrailingSlash(p)
-	}
-	return l[1], p, nil
-}
-
-// IsValidURI us a utility function used by vfssimple to determine if the given URI is a valid Azure URI
-func IsValidURI(u *url.URL) bool {
-	r := regexp.MustCompile(`.*\.blob\.core\.windows\.net`)
-
-	if u.Scheme == Scheme && r.MatchString(u.Host) {
-		return true
-	}
-	return false
 }

--- a/backend/azure/fileSystem_test.go
+++ b/backend/azure/fileSystem_test.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"errors"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -20,32 +19,32 @@ func (s *FileSystemTestSuite) TestVFSFileSystemImplementor() {
 }
 
 func (s *FileSystemTestSuite) TestNewFile() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs := NewFileSystem()
 	file, err := fs.NewFile("", "")
 	s.EqualError(err, "non-empty strings for container and path are required", "volume and path are required")
 	s.Nil(file)
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	file, err = fs.NewFile("temp", "")
 	s.EqualError(err, "non-empty strings for container and path are required", "volume and path are required")
 	s.Nil(file)
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	file, err = fs.NewFile("", "/blah/blah.txt")
 	s.EqualError(err, "non-empty strings for container and path are required", "volume and path are required")
 	s.Nil(file)
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	file, err = fs.NewFile("temp", "blah/blah.txt")
 	s.EqualError(err, "absolute file path is invalid - must include leading slash and may not include trailing slash",
 		"the path is invalid so we expect an error")
 	s.Nil(file, "Since an error was returned we expect a nil file to be returned")
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	file, err = fs.NewFile("temp", "/foo/bar/test.txt")
 	s.NoError(err, "The file path and volume are valid so we expect no errors")
 	s.NotNil(file, "No error was returned so we expect to get a non-nil file struct")
-	s.Equal("https://test-container.blob.core.windows.net/temp/foo/bar/test.txt", file.String())
+	s.Equal("az://temp/foo/bar/test.txt", file.String())
 }
 
 func (s *FileSystemTestSuite) TestNewFile_NilReceiver() {
@@ -56,50 +55,50 @@ func (s *FileSystemTestSuite) TestNewFile_NilReceiver() {
 }
 
 func (s *FileSystemTestSuite) TestNewLocation() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs := NewFileSystem()
 	loc, err := fs.NewLocation("", "")
 	s.Error(err, "volume and path are required")
 	s.Nil(loc, "volume and path are required")
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("", "/foo/bar/")
 	s.Error(err, "volume and path are required")
 	s.Nil(loc, "volume and path are required")
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "")
 	s.Error(err, "volume and path are required")
 	s.Nil(loc, "volume and path are required")
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "foo/bar/")
 	s.EqualError(err, "absolute location path is invalid - must include leading and trailing slashes",
 		"The path does not start with a slash and therefore not an absolute path so we expect an error")
 	s.Nil(loc, "Since an error was returned the location is nil")
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "/foo/bar")
 	s.EqualError(err, "absolute location path is invalid - must include leading and trailing slashes",
 		"The path does not end with a slash and therefore not an absolute path so we expect an error")
 	s.Nil(loc, "Since an error was returned the location is nil")
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "/foo/bar/")
 	s.NoError(err, "the path is valid so we expect no error")
 	s.NotNil(loc, "Since there was no error we expect a non-nil location")
-	s.Equal("https://test-container.blob.core.windows.net/temp/foo/bar/", loc.String())
+	s.Equal("az://temp/foo/bar/", loc.String())
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "/path/../to/")
 	s.NoError(err, "the path is valid so we expect no error")
 	s.NotNil(loc, "Since there was no error we expect a non-nil location")
-	s.Equal("https://test-container.blob.core.windows.net/temp/to/", loc.String())
+	s.Equal("az://temp/to/", loc.String())
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "/path/./to/")
 	s.NoError(err, "the path is valid so we expect no error")
 	s.NotNil(loc, "Since there was no error we expect a non-nil location")
-	s.Equal("https://test-container.blob.core.windows.net/temp/path/to/", loc.String())
+	s.Equal("az://temp/path/to/", loc.String())
 }
 
 func (s *FileSystemTestSuite) TestNewLocation_NilReceiver() {
@@ -117,7 +116,7 @@ func (s *FileSystemTestSuite) TestName() {
 
 func (s *FileSystemTestSuite) TestScheme() {
 	fs := FileSystem{}
-	s.Equal("https", fs.Scheme())
+	s.Equal("az", fs.Scheme())
 }
 
 func (s *FileSystemTestSuite) TestRetry() {
@@ -161,54 +160,6 @@ func (s *FileSystemTestSuite) TestClient() {
 
 	fs = NewFileSystem()
 	s.NotNil(fs.Client())
-}
-
-func (s *FileSystemTestSuite) TestParsePath() {
-	uri := "https://my-account.blob.core.windows.net/my_container/foo/bar/baz/"
-	u, _ := url.Parse(uri)
-	volume, path, err := ParsePath(u.Path)
-	s.NoError(err, "Path is valid so we should not get an error")
-	s.Equal("my_container", volume)
-	s.Equal("/foo/bar/baz/", path)
-
-	uri = "https://my-account.blob.core.windows.net/my_container/"
-	u, _ = url.Parse(uri)
-	volume, path, err = ParsePath(u.Path)
-	s.NoError(err, "Path is valid so we should not get an error")
-	s.Equal("my_container", volume)
-	s.Equal("/", path)
-
-	uri = "https://my-account.blob.core.windows.net/"
-	u, _ = url.Parse(uri)
-	volume, path, err = ParsePath(u.Path)
-	s.Error(err, "a container is required so we should get an error")
-	s.Empty(volume, "we got an error so volume should be empty")
-	s.Empty(path, "we got an error so path should be empty")
-
-	uri = "https://my-account.blob.core.windows.net/my_container/foo/bar/baz.txt"
-	u, _ = url.Parse(uri)
-	volume, path, err = ParsePath(u.Path)
-	s.NoError(err, "File Path is valid so we should not get an error")
-	s.Equal("my_container", volume)
-	s.Equal("/foo/bar/baz.txt", path)
-}
-
-func (s *FileSystemTestSuite) TestIsValidURI() {
-	uri := "https://my-account.blob.core.windows.net/my_container/foo/bar/baz/"
-	u, _ := url.Parse(uri)
-	s.True(IsValidURI(u), "the uri should be recognized as an Azure uri")
-
-	uri = "foo://my-account.blob.core.windows.net/my_container/foo/bar/baz/"
-	u, _ = url.Parse(uri)
-	s.False(IsValidURI(u), "the uri has an invalid scheme so it is not an Azure uri")
-
-	uri = "https://yadda.yadda.yadda/my_container/foo/bar/baz/"
-	u, _ = url.Parse(uri)
-	s.False(IsValidURI(u), "the host does not match .*.blob.core.windows.net so it is not an Azure uri")
-
-	uri = "foo://yadda.yadda.yadda/my_container/foo/bar/baz/"
-	u, _ = url.Parse(uri)
-	s.False(IsValidURI(u), "nothing ab out this uri is right...")
 }
 
 func TestAzureFileSystem(t *testing.T) {

--- a/backend/azure/file_test.go
+++ b/backend/azure/file_test.go
@@ -84,15 +84,15 @@ func (s *FileTestSuite) TestWrite() {
 }
 
 func (s *FileTestSuite) TestString() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-account"})
+	fs := NewFileSystem()
 	l, _ := fs.NewLocation("temp", "/foo/bar/")
 	f, _ := l.NewFile("blah.txt")
-	s.Equal("https://test-account.blob.core.windows.net/temp/foo/bar/blah.txt", f.String())
+	s.Equal("az://temp/foo/bar/blah.txt", f.String())
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-account"})
+	fs = NewFileSystem()
 	l, _ = fs.NewLocation("folder", "/blah/")
 	f, _ = l.NewFile("file.txt")
-	s.Equal("https://test-account.blob.core.windows.net/folder/blah/file.txt", f.String())
+	s.Equal("az://folder/blah/file.txt", f.String())
 }
 
 func (s *FileTestSuite) TestExists() {
@@ -127,11 +127,11 @@ func (s *FileTestSuite) TestCloseWithContentType() {
 }
 
 func (s *FileTestSuite) TestLocation() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-account"})
+	fs := NewFileSystem()
 	f, _ := fs.NewFile("test-container", "/file.txt")
 	l := f.Location()
 	s.NotNil(l)
-	s.Equal("https://test-account.blob.core.windows.net/test-container/", l.URI())
+	s.Equal("az://test-container/", l.URI())
 }
 
 func (s *FileTestSuite) TestCopyToLocation() {
@@ -265,7 +265,7 @@ func (s *FileTestSuite) TestSize_NonExistentFile() {
 }
 
 func (s *FileTestSuite) TestPath() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-account"})
+	fs := NewFileSystem()
 	f, _ := fs.NewFile("test-container", "/foo/bar/blah.txt")
 	s.Equal("/foo/bar/blah.txt", f.Path())
 
@@ -310,13 +310,13 @@ func (s *FileTestSuite) TestTouchWithContentType() {
 }
 
 func (s *FileTestSuite) TestURI() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs := NewFileSystem()
 	f, _ := fs.NewFile("temp", "/foo/bar/blah.txt")
-	s.Equal("https://test-container.blob.core.windows.net/temp/foo/bar/blah.txt", f.URI())
+	s.Equal("az://temp/foo/bar/blah.txt", f.URI())
 
-	fs = NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs = NewFileSystem()
 	f, _ = fs.NewFile("folder", "/blah/file.txt")
-	s.Equal("https://test-container.blob.core.windows.net/folder/blah/file.txt", f.URI())
+	s.Equal("az://folder/blah/file.txt", f.URI())
 }
 
 func (s *FileTestSuite) TestCheckTempFile() {

--- a/backend/azure/location.go
+++ b/backend/azure/location.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"errors"
-	"fmt"
 	"path"
 	"regexp"
 	"strings"
@@ -121,7 +120,7 @@ func (l *Location) Exists() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	_, err = client.Properties(l.ContainerURL(), "")
+	_, err = client.Properties(l.container, "")
 	if err != nil {
 		return false, nil
 	}
@@ -194,14 +193,7 @@ func (l *Location) DeleteFile(relFilePath string, opts ...options.DeleteOption) 
 	return file.Delete(opts...)
 }
 
-// URI returns a URI string for the azure location.
+// URI returns the Location's URI as a string.
 func (l *Location) URI() string {
-	return fmt.Sprintf("%s://%s%s", l.fileSystem.Scheme(), utils.EnsureTrailingSlash(l.fileSystem.Host()),
-		utils.EnsureTrailingSlash(path.Join(l.container, l.path)))
-}
-
-// ContainerURL returns the URL for the Azure Blob Storage container.
-func (l *Location) ContainerURL() string {
-	return fmt.Sprintf("%s://%s%s", l.fileSystem.Scheme(), utils.EnsureTrailingSlash(l.fileSystem.Host()),
-		utils.EnsureTrailingSlash(l.container))
+	return utils.GetLocationURI(l)
 }

--- a/backend/azure/location_test.go
+++ b/backend/azure/location_test.go
@@ -20,16 +20,16 @@ func (s *LocationTestSuite) TestVFSLocationImplementor() {
 }
 
 func (s *LocationTestSuite) TestString() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-account"})
+	fs := NewFileSystem()
 	l, _ := fs.NewLocation("test-container", "/")
-	s.Equal("https://test-account.blob.core.windows.net/test-container/", l.String())
+	s.Equal("az://test-container/", l.String())
 
 	err := l.ChangeDir("foo/bar/baz/")
 	s.NoError(err, "Should change directories successfully")
-	s.Equal("https://test-account.blob.core.windows.net/test-container/foo/bar/baz/", l.String())
+	s.Equal("az://test-container/foo/bar/baz/", l.String())
 
 	l, _ = fs.NewLocation("temp", "/foo/bar/baz/")
-	s.Equal("https://test-account.blob.core.windows.net/temp/foo/bar/baz/", l.String())
+	s.Equal("az://temp/foo/bar/baz/", l.String())
 }
 
 func (s *LocationTestSuite) TestList() {
@@ -186,7 +186,7 @@ func (s *LocationTestSuite) TestFileSystem() {
 }
 
 func (s *LocationTestSuite) TestNewFile() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-container"})
+	fs := NewFileSystem()
 	l, _ := fs.NewLocation("test-container", "/folder/")
 
 	f, err := l.NewFile("")
@@ -208,7 +208,7 @@ func (s *LocationTestSuite) TestNewFile() {
 	s.NoError(err, "The file path is valid so we expect no error to be returned")
 	s.NotNil(f, "The call to NewFile did not return an error so we expect a non-nil pointer to a file struct")
 	s.Equal("/folder/foo/bar.txt", f.Path())
-	s.Equal("https://test-container.blob.core.windows.net/test-container/folder/foo/bar.txt", f.URI())
+	s.Equal("az://test-container/folder/foo/bar.txt", f.URI())
 }
 
 func (s *LocationTestSuite) TestNewFile_NilReceiver() {
@@ -233,23 +233,17 @@ func (s *LocationTestSuite) TestDeleteFile_DoesNotExist() {
 }
 
 func (s *LocationTestSuite) TestURI() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-account"})
+	fs := NewFileSystem()
 	l, _ := fs.NewLocation("test-container", "/")
-	s.Equal("https://test-account.blob.core.windows.net/test-container/", l.URI())
+	s.Equal("az://test-container/", l.URI())
 
 	err := l.ChangeDir("foo/bar/baz/")
 	s.NoError(err, "Should change directories successfully")
-	s.Equal("https://test-account.blob.core.windows.net/test-container/foo/bar/baz/", l.URI())
+	s.Equal("az://test-container/foo/bar/baz/", l.URI())
 
 	vfsLoc, err := fs.NewLocation("temp", "/foo/bar/baz/")
 	s.NoError(err, "Path is valid so we expect no errors")
-	s.Equal("https://test-account.blob.core.windows.net/temp/foo/bar/baz/", vfsLoc.URI())
-}
-
-func (s *LocationTestSuite) TestContainerURL() {
-	fs := NewFileSystem().WithOptions(Options{AccountName: "test-account"})
-	l, _ := fs.NewLocation("test-container", "/some/folder/")
-	s.Equal("https://test-account.blob.core.windows.net/test-container/", l.(*Location).ContainerURL())
+	s.Equal("az://temp/foo/bar/baz/", vfsLoc.URI())
 }
 
 func TestAzureLocation(t *testing.T) {

--- a/backend/azure/options.go
+++ b/backend/azure/options.go
@@ -10,6 +10,9 @@ import (
 
 // Options contains options necessary for the azure vfs implementation
 type Options struct {
+	// ServiceURL holds the base URL used for all service requests.
+	ServiceURL string
+
 	// AccountName holds the Azure Blob Storage account name for authentication.  This field is required for all
 	// authentication types.
 	AccountName string
@@ -50,6 +53,7 @@ type Options struct {
 //	  *VFS_AZURE_ENV_NAME
 func NewOptions() *Options {
 	return &Options{
+		ServiceURL:             os.Getenv("VFS_AZURE_SERVICE_URL"),
 		AccountName:            os.Getenv("VFS_AZURE_STORAGE_ACCOUNT"),
 		AccountKey:             os.Getenv("VFS_AZURE_STORAGE_ACCESS_KEY"),
 		TenantID:               os.Getenv("VFS_AZURE_TENANT_ID"),

--- a/backend/testsuite/backend_integration_test.go
+++ b/backend/testsuite/backend_integration_test.go
@@ -33,10 +33,6 @@ type vfsTestSuite struct {
 }
 
 func buildExpectedURI(fs vfs.FileSystem, volume, path string) string {
-	if fs.Name() == "azure" {
-		azFs := fs.(*azure.FileSystem)
-		return fmt.Sprintf("%s://%s/%s%s", fs.Scheme(), azFs.Host(), volume, path)
-	}
 	return fmt.Sprintf("%s://%s%s", fs.Scheme(), volume, path)
 }
 
@@ -70,7 +66,7 @@ func (s *vfsTestSuite) SetupSuite() {
 			s.testLocations[l.FileSystem().Scheme()] = l.(*gs.Location)
 		case "mem":
 			s.testLocations[l.FileSystem().Scheme()] = l.(*mem.Location)
-		case "https":
+		case "az":
 			s.testLocations[l.FileSystem().Scheme()] = l.(*azure.Location)
 		case "ftp":
 			s.testLocations[l.FileSystem().Scheme()] = l.(*ftp.Location)

--- a/backend/testsuite/io_integration_test.go
+++ b/backend/testsuite/io_integration_test.go
@@ -190,7 +190,7 @@ func (s *ioTestSuite) SetupSuite() {
 				s.testLocations[l.FileSystem().Scheme()] = l.(*gs.Location)
 			case "mem":
 				s.testLocations[l.FileSystem().Scheme()] = l.(*mem.Location)
-			case "https":
+			case "az":
 				s.testLocations[l.FileSystem().Scheme()] = l.(*azure.Location)
 			case "ftp":
 				s.testLocations[l.FileSystem().Scheme()] = l.(*ftp.Location)

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -83,23 +83,6 @@ const Scheme = "https"
 ```
 Scheme defines the scheme for the azure implementation
 
-#### func  IsValidURI
-
-```go
-func IsValidURI(u *url.URL) bool
-```
-IsValidURI us a utility function used by vfssimple to determine if the given URI
-is a valid Azure URI
-
-#### func  ParsePath
-
-```go
-func ParsePath(p string) (host, pth string, err error)
-```
-ParsePath is a utility function used by vfssimple to separate the host from the
-path. The first parameter returned is the host and the second parameter is the
-path.
-
 ### type BlobProperties
 
 ```go
@@ -424,14 +407,6 @@ func (fs *FileSystem) Client() (Client, error)
 ```
 Client returns a Client to perform operations against Azure Blob Storage
 
-#### func (*FileSystem) Host
-
-```go
-func (fs *FileSystem) Host() string
-```
-Host returns the host portion of the URI. For azure this consists of
-<account_name>.blob.core.windows.net.
-
 #### func (*FileSystem) Name
 
 ```go
@@ -497,13 +472,6 @@ Location is the azure implementation of vfs.Location
 func (l *Location) ChangeDir(relLocPath string) error
 ```
 ChangeDir changes the current location's path to the new, relative path.
-
-#### func (*Location) ContainerURL
-
-```go
-func (l *Location) ContainerURL() string
-```
-ContainerURL returns the URL for the Azure Blob Storage container.
 
 #### func (*Location) DeleteFile
 

--- a/vfssimple/vfssimple.go
+++ b/vfssimple/vfssimple.go
@@ -9,7 +9,6 @@ import (
 	"github.com/c2fo/vfs/v7"
 	"github.com/c2fo/vfs/v7/backend"
 	_ "github.com/c2fo/vfs/v7/backend/all" // register all backends
-	"github.com/c2fo/vfs/v7/backend/azure"
 	"github.com/c2fo/vfs/v7/backend/mem"
 	"github.com/c2fo/vfs/v7/backend/os"
 )

--- a/vfssimple/vfssimple.go
+++ b/vfssimple/vfssimple.go
@@ -75,9 +75,6 @@ func parseURI(uri string) (scheme, authority, path string, err error) {
 	// validate authority
 	authority = u.Host
 	path = u.Path
-	if azure.IsValidURI(u) {
-		authority, path, err = azure.ParsePath(path)
-	}
 
 	if u.User.String() != "" {
 		authority = fmt.Sprintf("%s@%s", u.User, u.Host)

--- a/vfssimple/vfssimple_test.go
+++ b/vfssimple/vfssimple_test.go
@@ -129,10 +129,10 @@ func (s *vfsSimpleSuite) TestParseURI() {
 			path:      "/path/to/file.txt",
 		},
 		{
-			uri:       "https://myaccount.blob.core.windows.net/mycontainer/path/to/file.txt",
+			uri:       "az://mycontainer/path/to/file.txt",
 			err:       nil,
 			message:   "valid azure uri",
-			scheme:    "https",
+			scheme:    "az",
 			authority: "mycontainer",
 			path:      "/path/to/file.txt",
 		},


### PR DESCRIPTION
Implements suggestion from #224.
This has been validated against a local Azurite server but not public Azure itself.
Note that 4 redundant functions have been removed, so this is technically a breaking change. They can be reintroduced if desired.