### PR TITLE
Add Username option field to SFTP and FTP implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added Username field to SFTP and FTP Options structs with environment variable support (VFS_SFTP_USERNAME and VFS_FTP_USERNAME). Fixes #242.
 
 ## [v7.1.0] - 2025-03-19
 ### Added

--- a/backend/sftp/options.go
+++ b/backend/sftp/options.go
@@ -21,6 +21,7 @@ const systemWideKnownHosts = "/etc/ssh/ssh_known_hosts"
 
 // Options holds sftp-specific options.  Currently only client options are used.
 type Options struct {
+	Username           string              `json:"username,omitempty"`       // env var VFS_SFTP_USERNAME
 	Password           string              `json:"password,omitempty"`       // env var VFS_SFTP_PASSWORD
 	KeyFilePath        string              `json:"keyFilePath,omitempty"`    // env var VFS_SFTP_KEYFILE
 	KeyPassphrase      string              `json:"keyPassphrase,omitempty"`  // env var VFS_SFTP_KEYFILE_PASSPHRASE
@@ -120,7 +121,12 @@ func GetClient(authority authority.Authority, opts Options) (sftpclient *_sftp.C
 
 	// Define the Client Config
 	config := getSShConfig(opts)
-	config.User = authority.UserInfo().Username()
+	// Use username from Options if available, otherwise from authority
+	if opts.Username != "" {
+		config.User = opts.Username
+	} else {
+		config.User = authority.UserInfo().Username()
+	}
 	config.Auth = authMethods
 	config.HostKeyCallback = hostKeyCallback
 

--- a/backend/sftp/options_test.go
+++ b/backend/sftp/options_test.go
@@ -429,6 +429,9 @@ func (o *optionsSuite) TestGetClient() {
 	auth, err := authority.NewAuthority("someuser@badhost")
 	o.NoError(err)
 
+	authNoUser, err := authority.NewAuthority("badhost")
+	o.NoError(err)
+
 	tests := []getClientTest{
 		{
 			authority: auth,
@@ -459,6 +462,17 @@ func (o *optionsSuite) TestGetClient() {
 			hasError: true,
 			errRegex: "ssh: no key found",
 			message:  "getclient - bad known hosts",
+		},
+		{
+			authority: authNoUser,
+			options: Options{
+				Username:           "customuser",
+				Password:           "somepassword",
+				KnownHostsCallback: ssh.FixedHostKey(o.publicKey),
+			},
+			hasError: true,
+			errRegex: ".*",
+			message:  "getclient - username from options",
 		},
 	} // #nosec - InsecureIgnoreHostKey only used for testing
 

--- a/docs/ftp.md
+++ b/docs/ftp.md
@@ -552,6 +552,7 @@ Authority returns the authority of the location.
 
 ```go
 type Options struct {
+	Username    string // env var VFS_FTP_USERNAME
 	Password    string // env var VFS_FTP_PASSWORD
 	Protocol    string // env var VFS_FTP_PROTOCOL
 	DisableEPSV *bool  // env var VFS_DISABLE_EPSV

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -576,6 +576,7 @@ Authority returns the authority of the location.
 
 ```go
 type Options struct {
+	Username           string              `json:"username,omitempty"`       // env var VFS_SFTP_USERNAME
 	Password           string              `json:"password,omitempty"`       // env var VFS_SFTP_PASSWORD
 	KeyFilePath        string              `json:"keyFilePath,omitempty"`    // env var VFS_SFTP_KEYFILE
 	KeyPassphrase      string              `json:"keyPassphrase,omitempty"`  // env var VFS_SFTP_KEYFILE_PASSPHRASE


### PR DESCRIPTION
   Fixes #242

   This PR adds the ability to specify a username via Options.Username or environment variables (VFS_SFTP_USERNAME/VFS_FTP_USERNAME) instead of only via the authority URI.

   Changes:
   - Added Username field to SFTP Options struct with env var support
   - Added Username field to FTP Options struct with env var support
   - Updated credential priority order to prefer Options over env vars over authority
   - Updated documentation
   - Added tests for new functionality

   Now users can connect to FTP/SFTP servers using:
   ```go
   fs := sftp.NewFileSysetm(
       sftp.WithOptions(
           &sftp.Options{
               Username: "bob",
               Password: "my-secret",
           },
       ),
   )
   file, _ := fs.NewFile("host.com:22", "/some/path/file.txt")
   ```
   
   Or with environment variables:
   ```go
   _ := os.SetEnv("VFS_SFTP_USERNAME", "bob")
   _ := os.SetEnv("VFS_SFTP_PASSWORD", "my-secret")
   file, _ := vfssimple.NewFile("sftp://host.com:22/some/path/file.txt")
   ```