### PR TITLE
Remove Deprecated Volume and ChangeDir methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Remove Deprecated Volume and ChangeDir methods. Fixes #236
 
 ## [v7.4.1] - 2025-05-05
 ### Security

--- a/backend/azure/location.go
+++ b/backend/azure/location.go
@@ -104,15 +104,6 @@ func (l *Location) ListByRegex(regex *regexp.Regexp) ([]string, error) {
 	return filtered, nil
 }
 
-// Volume returns the azure container.  Azure containers are equivalent to AWS Buckets
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the authority for the Location
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -152,30 +143,6 @@ func (l *Location) NewLocation(relLocPath string) (vfs.Location, error) {
 		path:       path.Join(l.path, relLocPath),
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir changes the current location's path to the new, relative path.
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relLocPath string) error {
-	if l == nil {
-		return errors.New(errNilLocationReceiver)
-	}
-
-	err := utils.ValidateRelativeLocationPath(relLocPath)
-	if err != nil {
-		return err
-	}
-
-	newLoc, err := l.NewLocation(relLocPath)
-	if err != nil {
-		return err
-	}
-	*l = *newLoc.(*Location)
-
-	return nil
 }
 
 // FileSystem returns the azure FileSystem instance

--- a/backend/azure/location_test.go
+++ b/backend/azure/location_test.go
@@ -64,18 +64,6 @@ func (s *LocationTestSuite) TestListByRegex() {
 	s.Equal("file2.txt", listing[1])
 }
 
-//nolint:staticcheck // deprecated method test
-func (s *LocationTestSuite) TestVolume() {
-	fs := NewFileSystem()
-	l, err := fs.NewLocation("test-container", "/")
-	s.NoError(err)
-	s.Equal("test-container", l.Volume())
-
-	l, err = fs.NewLocation("another-container", "/")
-	s.NoError(err)
-	s.Equal("another-container", l.Volume())
-}
-
 func (s *LocationTestSuite) TestPath() {
 	l := Location{path: "/foo/bar/"}
 	s.Equal("/foo/bar/", l.Path())
@@ -148,48 +136,6 @@ func (s *LocationTestSuite) TestNewLocation_NilReceiver() {
 	nl, err := l.NewLocation("test-container/")
 	s.EqualError(err, "azure.Location receiver pointer must be non-nil", "The receiver for NewLocation must be non-nil so we expect an error")
 	s.Nil(nl, "An error was returned so we expect a nil location to be returned")
-}
-
-//nolint:staticcheck // deprecated method test
-func (s *LocationTestSuite) TestChangeDir() {
-	l, err := NewFileSystem().NewLocation("test-container", "/")
-	s.NoError(err)
-	l = l.(*Location)
-	err = l.ChangeDir("some-dir/")
-	s.NoError(err)
-	s.Equal("/some-dir/", l.Path())
-
-	err = l.ChangeDir("path/../to/./new/dir/")
-	s.NoError(err)
-	s.Equal("/some-dir/to/new/dir/", l.Path())
-
-	l, err = NewFileSystem().NewLocation("test-container", "/")
-	s.NoError(err)
-	l = l.(*Location)
-	err = l.ChangeDir("/test-dir/")
-	s.EqualError(err, "relative location path is invalid - may not include leading slash but must include trailing slash",
-		"The path begins with a slash and therefore is not a relative path so this should return an error")
-
-	l, err = NewFileSystem().NewLocation("test-container", "/")
-	s.NoError(err)
-	l = l.(*Location)
-	err = l.ChangeDir("test-dir")
-	s.EqualError(err, "relative location path is invalid - may not include leading slash but must include trailing slash",
-		"The path does not end with a slash and therefore is not a relative path so this should return an error")
-
-	l, err = NewFileSystem().NewLocation("test-container", "/")
-	s.NoError(err)
-	l = l.(*Location)
-	err = l.ChangeDir("")
-	s.EqualError(err, "relative location path is invalid - may not include leading slash but must include trailing slash",
-		"An empty relative path does not end with a slash and therefore is not a valid relative path so this should return an error")
-}
-
-func (s *LocationTestSuite) TestChangeDir_NilReceiver() {
-	var l *Location
-	s.Nil(l)
-	err := l.ChangeDir("")
-	s.EqualError(err, "azure.Location receiver pointer must be non-nil")
 }
 
 func (s *LocationTestSuite) TestFileSystem() {

--- a/backend/ftp/location.go
+++ b/backend/ftp/location.go
@@ -129,15 +129,6 @@ func (l *Location) ListByRegex(regex *regexp.Regexp) ([]string, error) {
 	return filteredFilenames, nil
 }
 
-// Volume returns the Authority the location is contained in.
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the Authority the location is contained in.
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -194,28 +185,6 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 		path:       path.Join(l.path, relativePath),
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir takes a relative path, and modifies the underlying Location's path. The caller is modified by this
-// so the only return is any error. For this implementation there are no errors.
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relativePath string) error {
-
-	err := utils.ValidateRelativeLocationPath(relativePath)
-	if err != nil {
-		return err
-	}
-
-	newLoc, err := l.NewLocation(relativePath)
-	if err != nil {
-		return err
-	}
-	*l = *newLoc.(*Location)
-
-	return nil
 }
 
 // NewFile uses the properties of the calling location to generate a vfs.File (backed by an ftp.File). The filePath

--- a/backend/ftp/location_test.go
+++ b/backend/ftp/location_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/c2fo/vfs/v7/backend/ftp/mocks"
 	"github.com/c2fo/vfs/v7/utils"
-	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
 type locationTestSuite struct {
@@ -349,19 +348,6 @@ func (lt *locationTestSuite) TestString() {
 	lt.Equal("ftp://user@host.com/blah/file.txt", file.String(), "file string with user, pass, host")
 }
 
-//nolint:staticcheck // deprecated method test
-func (lt *locationTestSuite) TestVolume() {
-	authorityStr := "user@host.com:21"
-	loc, err := lt.ftpfs.NewLocation(authorityStr, "/blah/")
-	lt.NoError(err)
-	lt.Equal("user@host.com:21", loc.Volume(), "Volume() should return the authority string on location.")
-
-	authorityStr = "user:password@host.com"
-	loc, err = lt.ftpfs.NewLocation(authorityStr, "/blah/")
-	lt.NoError(err)
-	lt.Equal("user@host.com", loc.Volume(), "Volume() should return the authority string on location.")
-}
-
 func (lt *locationTestSuite) TestPath() {
 	loc, err := lt.ftpfs.NewLocation("host.com", "/path/")
 	lt.NoError(err)
@@ -494,30 +480,6 @@ func (lt *locationTestSuite) TestExists() {
 	lt.False(exists, "exists should be false on error")
 
 	lt.client.AssertExpectations(lt.T())
-}
-
-func (lt *locationTestSuite) TestChangeDir() {
-	loc := &Location{fileSystem: lt.ftpfs, path: "/", authority: authority.Authority{}}
-
-	err1 := loc.ChangeDir("../")
-	lt.NoError(err1, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err2 := loc.ChangeDir("hello/")
-	lt.NoError(err2, "no error expected")
-	lt.Equal("/hello/", loc.Path())
-
-	err3 := loc.ChangeDir("../.././../")
-	lt.NoError(err3, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err4 := loc.ChangeDir("here/is/a/path/")
-	lt.NoError(err4, "no error expected")
-	lt.Equal("/here/is/a/path/", loc.Path())
-
-	err5 := loc.ChangeDir("../")
-	lt.NoError(err5, "no error expected")
-	lt.Equal("/here/is/a/", loc.Path())
 }
 
 func (lt *locationTestSuite) TestNewLocation() {

--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -98,15 +98,6 @@ func (l *Location) ListByRegex(regex *regexp.Regexp) ([]string, error) {
 	return filteredKeys, nil
 }
 
-// Volume returns the GCS bucket name.
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the Authority for the Location.
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -148,34 +139,6 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 		prefix:     path.Join(l.prefix, relativePath),
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir changes the current location's path to the new, relative path.
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relativePath string) error {
-	if l == nil {
-		return errors.New("non-nil gs.Location pointer is required")
-	}
-
-	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
-	}
-
-	err := utils.ValidateRelativeLocationPath(relativePath)
-	if err != nil {
-		return err
-	}
-
-	newLoc, err := l.NewLocation(relativePath)
-	if err != nil {
-		return err
-	}
-	*l = *newLoc.(*Location)
-
-	return nil
 }
 
 // FileSystem returns the GCS file system instance.

--- a/backend/gs/location_test.go
+++ b/backend/gs/location_test.go
@@ -112,18 +112,6 @@ func (lt *locationTestSuite) TestList() {
 	}
 }
 
-//nolint:staticcheck // deprecated method test
-func (lt *locationTestSuite) TestVolume() {
-	server := fakestorage.NewServer(Objects{})
-	defer server.Stop()
-	fs := NewFileSystem(WithClient(server.Client()))
-
-	bucket := "c2fo-vfs-a"
-	loc, err := fs.NewLocation(bucket, "/")
-	lt.NoError(err)
-	lt.Equal(bucket, loc.Volume(), "Volume() should return the bucket name on location.")
-}
-
 func (lt *locationTestSuite) TestPath() {
 	server := fakestorage.NewServer(Objects{})
 	defer server.Stop()
@@ -217,41 +205,6 @@ func (lt *locationTestSuite) TestExists_false() {
 	exists, err := loc.Exists()
 	lt.NoError(err, "No error expected from Exists")
 	lt.False(exists, "Call to Exists expected to return true.")
-}
-
-func (lt *locationTestSuite) TestChangeDir() {
-	server := fakestorage.NewServer(Objects{})
-	defer server.Stop()
-	fs := NewFileSystem().WithClient(server.Client())
-
-	// test nil Location
-	var nilLoc *Location
-	err := nilLoc.ChangeDir("path/to/")
-	lt.EqualErrorf(err, "non-nil gs.Location pointer is required", "error expected for nil location")
-
-	auth, err := authority.NewAuthority("bucket")
-	lt.NoError(err)
-	loc := &Location{fileSystem: fs, prefix: "/", authority: auth}
-
-	err1 := loc.ChangeDir("../")
-	lt.NoError(err1, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err2 := loc.ChangeDir("hello/")
-	lt.NoError(err2, "no error expected")
-	lt.Equal("/hello/", loc.Path())
-
-	err3 := loc.ChangeDir("../.././../")
-	lt.NoError(err3, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err4 := loc.ChangeDir("here/is/a/path/")
-	lt.NoError(err4, "no error expected")
-	lt.Equal("/here/is/a/path/", loc.Path())
-
-	err5 := loc.ChangeDir("../")
-	lt.NoError(err5, "no error expected")
-	lt.Equal("/here/is/a/", loc.Path())
 }
 
 func (lt *locationTestSuite) TestNewLocation() {

--- a/backend/mem/location.go
+++ b/backend/mem/location.go
@@ -86,15 +86,6 @@ func (l *Location) ListByRegex(regex *regexp.Regexp) ([]string, error) {
 	return list, nil
 }
 
-// Volume returns the volume of the current FileSystem.
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the authority of the current location
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -139,20 +130,6 @@ func (l *Location) NewLocation(relLocPath string) (vfs.Location, error) {
 		exists:     false,
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir simply changes the directory of the location
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relLocPath string) error {
-	err := utils.ValidateRelativeLocationPath(relLocPath)
-	if err != nil {
-		return err
-	}
-	l.name = path.Join(l.name, relLocPath)
-	return nil
 }
 
 // FileSystem returns the type of file system location exists on, if it exists at all

--- a/backend/mem/location_test.go
+++ b/backend/mem/location_test.go
@@ -228,32 +228,6 @@ func (s *memLocationTest) TestNewFileSameName() {
 	s.Equal(expectedText, string(expectedSlice))
 }
 
-//nolint:staticcheck // deprecated method test
-func (s *memLocationTest) TestChangeDir() {
-	newFile, nerr := s.fileSystem.NewFile("", "/dir/to/change/change.txt")
-	s.NoError(nerr, "unexpected error creating a new file")
-
-	s.NoError(newFile.Touch(), "unexpected error touching file")
-	loc := newFile.Location()
-
-	// changing directory
-	s.NoError(loc.ChangeDir("extraDir/"), "unexpected error while changing directory")
-	exists, eerr := loc.Exists()
-	s.NoError(eerr, "unexpected error checking for Existence")
-	s.True(exists)
-	s.NotEqual(newFile.Location().Path(), loc.Path())
-}
-
-//nolint:staticcheck // deprecated method test
-func (s *memLocationTest) TestVolume() {
-	newFile, nerr := s.fileSystem.NewFile("D:", "/path/to/file/example.txt")
-	s.NoError(nerr, "unexpected error creating a file")
-	s.NoError(newFile.Touch(), "unexpected error touching file")
-	s.NoError(newFile.Close(), "unexpected error closing file")
-	// For Unix, this returns an empty string. For windows, it would be something like 'C:'
-	s.Equal("D", newFile.Location().Volume())
-}
-
 // TestPath makes sure that locations return the correct paths, along with leading and trailing slashes
 func (s *memLocationTest) TestPath() {
 	file, nerr := s.fileSystem.NewFile("", "/some/file/test.txt")

--- a/backend/os/file_test.go
+++ b/backend/os/file_test.go
@@ -706,19 +706,6 @@ func (s *osFileTest) TestStringer() {
 	s.Equal(fmt.Sprintf("file://%s", filepath.ToSlash(filepath.Join(osLocationPath(s.tmploc), "some", "file", "test.txt"))), file.String())
 }
 
-//nolint:staticcheck // deprecated method test
-func (s *osFileTest) TestLocationRightAfterChangeDir() {
-	file, err := s.tmploc.NewFile("chdTest.txt")
-	s.NoError(err)
-	chDir := "someDir/"
-	loc := file.Location()
-	s.NotContains(loc.Path(), "someDir/", "location should not contain 'someDir/'")
-
-	err = loc.ChangeDir(chDir)
-	s.NoError(err)
-	s.Contains(loc.Path(), "someDir/", "location now should contain 'someDir/'")
-}
-
 func TestOSFile(t *testing.T) {
 	suite.Run(t, new(osFileTest))
 	_ = os.Remove("test_files/new.txt")

--- a/backend/os/location.go
+++ b/backend/os/location.go
@@ -116,15 +116,6 @@ func (l *Location) fileList(testEval fileTest) ([]string, error) {
 	return files, nil
 }
 
-// Volume returns the volume, if any, of the location. Given "C:\foo\bar" it returns "C:" on Windows. On other platforms it returns "".
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the location's authority as a string.
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -180,33 +171,6 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 		name:       path.Join(l.name, relativePath),
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir takes a relative path, and modifies the underlying Location's path. The caller is modified by this
-// so the only return is any error. For this implementation there are no errors.
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relativePath string) error {
-	if l == nil {
-		return errors.New("non-nil os.Location pointer is required")
-	}
-	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
-	}
-	err := utils.ValidateRelativeLocationPath(relativePath)
-	if err != nil {
-		return err
-	}
-
-	newLoc, err := l.NewLocation(relativePath)
-	if err != nil {
-		return err
-	}
-	*l = *newLoc.(*Location)
-
-	return nil
 }
 
 // FileSystem returns a vfs.FileSystem interface of the location's underlying file system.

--- a/backend/os/location_test.go
+++ b/backend/os/location_test.go
@@ -2,8 +2,6 @@ package os
 
 import (
 	"os"
-	"path"
-	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -124,24 +122,6 @@ func (s *osLocationTest) TestNewFile() {
 		s.Equal("/newrootfile.txt", newFile.Path(), "NewFile with relative path to root should update location correctly")
 		s.Equal("/", newFile.Location().Path(), "NewFile with relative path to root should update location correctly")
 	})
-}
-
-//nolint:staticcheck // deprecated method test
-func (s *osLocationTest) TestChangeDir() {
-	otherFile, _ := s.tmploc.NewFile("foo/foo.txt")
-	fileLocation := otherFile.Location()
-	cwd := fileLocation.Path()
-	err := fileLocation.ChangeDir("other/")
-	s.NoError(err, "change dir error not expected")
-	s.Equal(fileLocation.Path(), utils.EnsureTrailingSlash(path.Join(cwd, "other")))
-}
-
-//nolint:staticcheck // deprecated method test
-func (s *osLocationTest) TestVolume() {
-	volume := s.testFile.Location().Volume()
-
-	// For Unix, this returns an empty string. For windows, it would be something like 'C:'
-	s.Equal(filepath.VolumeName(os.TempDir()), volume)
 }
 
 func (s *osLocationTest) TestPath() {

--- a/backend/s3/location.go
+++ b/backend/s3/location.go
@@ -61,15 +61,6 @@ func (l *Location) ListByRegex(regex *regexp.Regexp) ([]string, error) {
 	return filteredKeys, nil
 }
 
-// Volume returns the bucket the location is contained in.
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the bucket the location is contained in.
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -122,35 +113,6 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 		prefix:     path.Join(l.prefix, relativePath),
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir takes a relative path, and modifies the underlying Location's path. The caller is modified by this
-// so the only return is any error. For this implementation there are no errors.
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relativePath string) error {
-	if l == nil {
-		return errors.New("non-nil s3.Location pointer is required")
-	}
-
-	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
-	}
-
-	err := utils.ValidateRelativeLocationPath(relativePath)
-	if err != nil {
-		return err
-	}
-
-	newLoc, err := l.NewLocation(relativePath)
-	if err != nil {
-		return err
-	}
-	*l = *newLoc.(*Location)
-
-	return nil
 }
 
 // NewFile uses the properties of the calling location to generate a vfs.File (backed by an s3.File). The filePath

--- a/backend/s3/location_test.go
+++ b/backend/s3/location_test.go
@@ -160,14 +160,6 @@ func (lt *locationTestSuite) TestListByRegex() {
 	lt.s3cliMock.AssertExpectations(lt.T())
 }
 
-//nolint:staticcheck // deprecated method test
-func (lt *locationTestSuite) TestVolume() {
-	bucket := "bucket"
-	loc, err := lt.fs.NewLocation(bucket, "/")
-	lt.NoError(err)
-	lt.Equal(bucket, loc.Volume(), "Volume() should return the bucket name on location.")
-}
-
 func (lt *locationTestSuite) TestPath() {
 	loc, err := lt.fs.NewLocation("bucket", "/path/")
 	lt.NoError(err)
@@ -246,37 +238,6 @@ func (lt *locationTestSuite) TestExists_false() {
 	lt.NoError(err, "No error expected from Exists")
 	lt.False(exists, "Call to Exists expected to return true.")
 	lt.s3cliMock.AssertExpectations(lt.T())
-}
-
-func (lt *locationTestSuite) TestChangeDir() {
-	// test nil Location
-	var nilLoc *Location
-	err := nilLoc.ChangeDir("path/to/")
-	lt.EqualErrorf(err, "non-nil s3.Location pointer is required", "error expected for nil location")
-
-	auth, err := authority.NewAuthority("bucket")
-	lt.NoError(err)
-	loc := &Location{fileSystem: lt.fs, prefix: "/", authority: auth}
-
-	err1 := loc.ChangeDir("../")
-	lt.NoError(err1, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err2 := loc.ChangeDir("hello/")
-	lt.NoError(err2, "no error expected")
-	lt.Equal("/hello/", loc.Path())
-
-	err3 := loc.ChangeDir("../.././../")
-	lt.NoError(err3, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err4 := loc.ChangeDir("here/is/a/path/")
-	lt.NoError(err4, "no error expected")
-	lt.Equal("/here/is/a/path/", loc.Path())
-
-	err5 := loc.ChangeDir("../")
-	lt.NoError(err5, "no error expected")
-	lt.Equal("/here/is/a/", loc.Path())
 }
 
 func (lt *locationTestSuite) TestNewLocation() {

--- a/backend/sftp/location.go
+++ b/backend/sftp/location.go
@@ -104,15 +104,6 @@ func (l *Location) ListByRegex(regex *regexp.Regexp) ([]string, error) {
 	return filteredFilenames, nil
 }
 
-// Volume returns the Authority the location is contained in.
-//
-// Deprecated: Use Authority instead.
-//
-//	authStr := loc.Authority().String()
-func (l *Location) Volume() string {
-	return l.Authority().String()
-}
-
 // Authority returns the Authority the location is contained in.
 func (l *Location) Authority() authority.Authority {
 	return l.authority
@@ -166,35 +157,6 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 		path:       path.Join(l.path, relativePath),
 		authority:  l.Authority(),
 	}, nil
-}
-
-// ChangeDir takes a relative path, and modifies the underlying Location's path. The caller is modified by this
-// so the only return is any error. For this implementation there are no errors.
-//
-// Deprecated: Use NewLocation instead:
-//
-//	loc, err := loc.NewLocation("../../")
-func (l *Location) ChangeDir(relativePath string) error {
-	if l == nil {
-		return errors.New("non-nil sftp.Location pointer receiver is required")
-	}
-
-	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
-	}
-
-	err := utils.ValidateRelativeLocationPath(relativePath)
-	if err != nil {
-		return err
-	}
-
-	newLoc, err := l.NewLocation(relativePath)
-	if err != nil {
-		return err
-	}
-	*l = *newLoc.(*Location)
-
-	return nil
 }
 
 // NewFile uses the properties of the calling location to generate a vfs.File (backed by an sftp.File). The filePath

--- a/backend/sftp/location_test.go
+++ b/backend/sftp/location_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/c2fo/vfs/v7/backend/sftp/mocks"
 	"github.com/c2fo/vfs/v7/utils"
-	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
 type locationTestSuite struct {
@@ -179,19 +178,6 @@ func (lt *locationTestSuite) TestString() {
 	lt.Equal("sftp://user@host.com/blah/file.txt", file.String(), "file string with user, pass, host")
 }
 
-//nolint:staticcheck // deprecated method test
-func (lt *locationTestSuite) TestVolume() {
-	authorityStr := "user@host.com:22"
-	loc, err := lt.sftpfs.NewLocation(authorityStr, "/blah/")
-	lt.NoError(err)
-	lt.Equal("user@host.com:22", loc.Volume(), "Volume() should return the authority string on location.")
-
-	authorityStr = "user:password@host.com"
-	loc, err = lt.sftpfs.NewLocation(authorityStr, "/blah/")
-	lt.NoError(err)
-	lt.Equal("user@host.com", loc.Volume(), "Volume() should return the authority string on location.")
-}
-
 func (lt *locationTestSuite) TestPath() {
 	loc, err := lt.sftpfs.NewLocation("host.com", "/path/")
 	lt.NoError(err)
@@ -293,35 +279,6 @@ func (lt *locationTestSuite) TestExists() {
 	lt.True(!exists, "Call to Exists expected to return false.")
 
 	lt.client.AssertExpectations(lt.T())
-}
-
-func (lt *locationTestSuite) TestChangeDir() {
-	// test nil Location
-	var nilLoc *Location
-	err := nilLoc.ChangeDir("path/to/")
-	lt.EqualErrorf(err, "non-nil sftp.Location pointer receiver is required", "error expected for nil location")
-
-	loc := &Location{fileSystem: lt.sftpfs, path: "/", authority: authority.Authority{}}
-
-	err1 := loc.ChangeDir("../")
-	lt.NoError(err1, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err2 := loc.ChangeDir("hello/")
-	lt.NoError(err2, "no error expected")
-	lt.Equal("/hello/", loc.Path())
-
-	err3 := loc.ChangeDir("../.././../")
-	lt.NoError(err3, "no error expected")
-	lt.Equal("/", loc.Path())
-
-	err4 := loc.ChangeDir("here/is/a/path/")
-	lt.NoError(err4, "no error expected")
-	lt.Equal("/here/is/a/path/", loc.Path())
-
-	err5 := loc.ChangeDir("../")
-	lt.NoError(err5, "no error expected")
-	lt.Equal("/here/is/a/", loc.Path())
 }
 
 func (lt *locationTestSuite) TestNewLocation() {

--- a/vfs.go
+++ b/vfs.go
@@ -77,15 +77,6 @@ type Location interface {
 	//     be checked first.
 	ListByRegex(regex *regexp.Regexp) ([]string, error)
 
-	// Volume returns the volume as string. In URI parlance, volume equates to authority.
-	// For example s3://mybucket/path/to/file.txt, volume would return "mybucket".
-	//
-	// Note: Some file systems may not have a volume and will return "".
-	//
-	// Deprecated: Use Authority instead.
-	//   authStr := loc.Authority().String()
-	Volume() string
-
 	// Authority returns the Authority for the Location.
 	//
 	// For example:
@@ -113,21 +104,6 @@ type Location interface {
 	//
 	//   * Accepts a relative location path.
 	NewLocation(relLocPath string) (Location, error)
-
-	// ChangeDir updates the existing Location's path to the provided relative location path.
-	//
-	// Given location:
-	// 	   loc := fs.NewLocation("file:///some/path/to/")
-	// calling:
-	//     loc.ChangeDir("../../")
-	// would update the current location instance to
-	// file:///some/.
-	//
-	//   * ChangeDir accepts a relative location path.
-	//
-	// Deprecated: Use NewLocation instead:
-	//     loc, err := loc.NewLocation("../../")
-	ChangeDir(relLocPath string) error
 
 	// FileSystem returns the underlying vfs.FileSystem struct for Location.
 	FileSystem() FileSystem


### PR DESCRIPTION
This PR fixes #236 

Remove depricated interfaces (ChangeDir and Volume)
Remove depricated implementations in all backends
Remove depreicated methods tests (ChangeDir and Volume)