### PR TITLE
Use utils.Ptr where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - General spelling and grammar corrections.
 - Check `vfsintegration` tests for lint issues.
 - Remove unnecessary mockery types and regenerate with the latest version.
+- Use the shared `utils.Ptr` func everywhere.
 
 ## [v7.8.1] - 2025-08-07
 ### Fixed

--- a/backend/azure/client_test.go
+++ b/backend/azure/client_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/c2fo/vfs/v7/utils"
 )
 
 func TestNewClient(t *testing.T) {
@@ -146,7 +148,7 @@ func TestDefaultClient_SetMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test the SetMetadata method
-	metadata := map[string]*string{"key": toPtr("value")}
+	metadata := map[string]*string{"key": utils.Ptr("value")}
 	err = client.SetMetadata(f, metadata)
 	assert.NoError(t, err)
 }

--- a/backend/azure/properties_test.go
+++ b/backend/azure/properties_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/c2fo/vfs/v7/utils"
 )
 
 func TestNewBlobProperties(t *testing.T) {
@@ -13,8 +15,8 @@ func TestNewBlobProperties(t *testing.T) {
 	lastModified := time.Now()
 	contentLength := int64(1024)
 	metadata := map[string]*string{
-		"key1": toPtr("value1"),
-		"key2": toPtr("value2"),
+		"key1": utils.Ptr("value1"),
+		"key2": utils.Ptr("value2"),
 	}
 
 	azureProps := blob.GetPropertiesResponse{
@@ -31,8 +33,4 @@ func TestNewBlobProperties(t *testing.T) {
 	assert.Equal(t, &contentLength, props.Size)
 	assert.Equal(t, &lastModified, props.LastModified)
 	assert.Equal(t, metadata, props.Metadata)
-}
-
-func toPtr(s string) *string {
-	return &s
 }

--- a/backend/ftp/file.go
+++ b/backend/ftp/file.go
@@ -44,8 +44,7 @@ func (f *File) LastModified() (*time.Time, error) {
 	if err != nil {
 		return nil, utils.WrapLastModifiedError(err)
 	}
-	t := entry.Time
-	return &t, nil
+	return utils.Ptr(entry.Time), nil
 }
 
 func (f *File) stat(ctx context.Context) (*_ftp.Entry, error) {

--- a/backend/ftp/options_test.go
+++ b/backend/ftp/options_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/c2fo/vfs/v7/utils"
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
@@ -42,7 +43,7 @@ func (s *optionsSuite) TestFetchUsername() {
 		{
 			description: "env var is set",
 			authority:   "host.com",
-			envVar:      ptrString("alice"),
+			envVar:      utils.Ptr("alice"),
 			expected:    "alice",
 		},
 		{
@@ -56,7 +57,7 @@ func (s *optionsSuite) TestFetchUsername() {
 		{
 			description: "options username overrides env var",
 			authority:   "host.com",
-			envVar:      ptrString("bob"),
+			envVar:      utils.Ptr("bob"),
 			options: Options{
 				Username: "alice",
 			},
@@ -99,17 +100,17 @@ func (s *optionsSuite) TestFetchPassword() {
 		{
 			description: "env var is set but with empty value",
 			expected:    "",
-			envVar:      ptrString(""),
+			envVar:      utils.Ptr(""),
 		},
 		{
 			description: "env var is set, value should override",
 			expected:    "12abc3",
-			envVar:      ptrString("12abc3"),
+			envVar:      utils.Ptr("12abc3"),
 		},
 		{
 			description: "option should override",
 			expected:    "xyz123",
-			envVar:      ptrString("12abc3"),
+			envVar:      utils.Ptr("12abc3"),
 			options: Options{
 				Password: "xyz123",
 			},
@@ -179,27 +180,27 @@ func (s *optionsSuite) TestIsDisableEPSV() {
 		},
 		{
 			description: "env var is set but empty",
-			envVar:      ptrString(""),
+			envVar:      utils.Ptr(""),
 			expected:    false,
 		},
 		{
 			description: "env var is set and is a non-true value",
-			envVar:      ptrString("not expected"),
+			envVar:      utils.Ptr("not expected"),
 			expected:    false,
 		},
 		{
 			description: "env var is set and is a `false` value",
-			envVar:      ptrString("false"),
+			envVar:      utils.Ptr("false"),
 			expected:    false,
 		},
 		{
 			description: "env var is set and is '1' value",
-			envVar:      ptrString("1"),
+			envVar:      utils.Ptr("1"),
 			expected:    true,
 		},
 		{
 			description: "env var is set and is 'true'",
-			envVar:      ptrString("true"),
+			envVar:      utils.Ptr("true"),
 			expected:    true,
 		},
 		{
@@ -218,7 +219,7 @@ func (s *optionsSuite) TestIsDisableEPSV() {
 		},
 		{
 			description: "env var is set true but Options is set to false'",
-			envVar:      ptrString("true"),
+			envVar:      utils.Ptr("true"),
 			options: Options{
 				DisableEPSV: &falseVal,
 			},
@@ -226,7 +227,7 @@ func (s *optionsSuite) TestIsDisableEPSV() {
 		},
 		{
 			description: "env var is set true but Options is set to false'",
-			envVar:      ptrString("false"),
+			envVar:      utils.Ptr("false"),
 			options: Options{
 				DisableEPSV: &trueVal,
 			},
@@ -343,22 +344,22 @@ func (s *optionsSuite) TestFetchProtocol() {
 		},
 		{
 			description: "env var is set but empty",
-			envVar:      ptrString(""),
+			envVar:      utils.Ptr(""),
 			expected:    "",
 		},
 		{
 			description: "env var is set to ftps",
-			envVar:      ptrString("FTPS"),
+			envVar:      utils.Ptr("FTPS"),
 			expected:    ProtocolFTPS,
 		},
 		{
 			description: "env var is set to ftpes",
-			envVar:      ptrString("FTPES"),
+			envVar:      utils.Ptr("FTPES"),
 			expected:    ProtocolFTPES,
 		},
 		{
 			description: "env var is set to garbage",
-			envVar:      ptrString("blah"),
+			envVar:      utils.Ptr("blah"),
 			expected:    "blah",
 		},
 		{
@@ -370,7 +371,7 @@ func (s *optionsSuite) TestFetchProtocol() {
 		},
 		{
 			description: "options set to FTPES - overriding FTPS",
-			envVar:      ptrString("FTPS"),
+			envVar:      utils.Ptr("FTPS"),
 			options: Options{
 				Protocol: ProtocolFTPES,
 			},
@@ -408,19 +409,19 @@ func (s *optionsSuite) TestFetchDialOptions() {
 		{
 			description: "protocol env var is set to FTPS",
 			authority:   "user@host.com",
-			envVar:      ptrString(ProtocolFTPS),
+			envVar:      utils.Ptr(ProtocolFTPS),
 			expected:    3,
 		},
 		{
 			description: "protocol env var is set to FTPES",
 			authority:   "user@host.com",
-			envVar:      ptrString(ProtocolFTPES),
+			envVar:      utils.Ptr(ProtocolFTPES),
 			expected:    3,
 		},
 		{
 			description: "protocol is set to empty",
 			authority:   "user@host.com",
-			envVar:      ptrString(""),
+			envVar:      utils.Ptr(""),
 			expected:    2,
 		},
 		{
@@ -481,8 +482,4 @@ func (s *optionsSuite) TestFetchDialOptions() {
 			s.Len(dialOpts, test.expected, test.description)
 		})
 	}
-}
-
-func ptrString(str string) *string {
-	return &str
 }

--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -249,8 +249,7 @@ func (f *File) Exists() (bool, error) {
 // Location simply returns the file's underlying location struct pointer
 func (f *File) Location() vfs.Location {
 	// copy the location
-	location := *f.memFile.location
-	return &location
+	return utils.Ptr(*f.memFile.location)
 }
 
 // CopyToLocation copies the current file to the given location.  If file exists

--- a/backend/os/file.go
+++ b/backend/os/file.go
@@ -51,8 +51,7 @@ func (f *File) LastModified() (*time.Time, error) {
 		return nil, utils.WrapLastModifiedError(err)
 	}
 
-	statsTime := stats.ModTime()
-	return &statsTime, nil
+	return utils.Ptr(stats.ModTime()), nil
 }
 
 // Name returns the base name of the file path.

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -781,7 +781,7 @@ func (ts *fileTestSuite) TestWriteOperations() {
 				if readErr != nil {
 					panic(readErr)
 				}
-				contents = ptr(string(b))
+				contents = utils.Ptr(string(b))
 			}).
 			Return(&s3.PutObjectOutput{}, nil)
 	}
@@ -930,8 +930,4 @@ func (ts *fileTestSuite) TestWriteOperations() {
 
 func TestFile(t *testing.T) {
 	suite.Run(t, new(fileTestSuite))
-}
-
-func ptr[T any](value T) *T {
-	return &value
 }

--- a/backend/sftp/file.go
+++ b/backend/sftp/file.go
@@ -43,8 +43,7 @@ func (f *File) LastModified() (*time.Time, error) {
 	if err != nil {
 		return nil, utils.WrapLastModifiedError(err)
 	}
-	t := userinfo.ModTime()
-	return &t, nil
+	return utils.Ptr(userinfo.ModTime()), nil
 }
 
 // Name returns the path portion of the file's path property. IE: "file.txt" of "sftp://someuser@host.com/some/path/to/file.txt

--- a/backend/sftp/options.go
+++ b/backend/sftp/options.go
@@ -48,8 +48,7 @@ func (o *Options) GetFileMode() (*os.FileMode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid file mode: %v", err)
 	}
-	mode := os.FileMode(parsed)
-	return &mode, nil
+	return utils.Ptr(os.FileMode(parsed)), nil
 }
 
 var defaultSSHConfig = &ssh.ClientConfig{

--- a/contrib/vfsevents/CHANGELOG.md
+++ b/contrib/vfsevents/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - General spelling and grammar corrections.
 - Regenerate mockery types with the latest version.
 - More reliable mock expectation assertions in unit tests.
+- Use the shared `utils.Ptr` func everywhere.
 
 ## [contrib/vfsevents/v1.0.1] - 2025-08-05
 ### Fixed

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c2fo/vfs/contrib/vfsevents"
 	"github.com/c2fo/vfs/v7"
 	"github.com/c2fo/vfs/v7/mocks"
+	"github.com/c2fo/vfs/v7/utils"
 	"github.com/c2fo/vfs/v7/vfssimple"
 )
 
@@ -197,8 +198,7 @@ func (s *PollerTestSuite) TestPoll() {
 				loc.EXPECT().List().Return([]string{"file1"}, nil)
 				file := mocks.NewFile(s.T())
 				file.EXPECT().URI().Return("scheme:///file1")
-				timeNow := time.Now().UTC()
-				file.EXPECT().LastModified().Return(&timeNow, nil)
+				file.EXPECT().LastModified().Return(utils.Ptr(time.Now().UTC()), nil)
 				file.EXPECT().Size().Return(uint64(100), nil)
 				loc.EXPECT().NewFile("file1").Return(file, nil)
 			},

--- a/options/newfile/contentType.go
+++ b/options/newfile/contentType.go
@@ -1,14 +1,16 @@
 // Package newfile provides options for creating new files in a virtual filesystem.
 package newfile
 
-import "github.com/c2fo/vfs/v7/options"
+import (
+	"github.com/c2fo/vfs/v7/options"
+	"github.com/c2fo/vfs/v7/utils"
+)
 
 const optionNameNewFileContentType = "newFileContentType"
 
 // WithContentType returns ContentType implementation of NewFileOption
 func WithContentType(contentType string) options.NewFileOption {
-	ct := ContentType(contentType)
-	return &ct
+	return utils.Ptr(ContentType(contentType))
 }
 
 // ContentType represents the NewFileOption that is used to explicitly specify a content type on created files.


### PR DESCRIPTION
The shared `utils.Ptr` func should be used everywhere.