### PR TITLE
Additional linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usetesting
     - wastedassign
     - whitespace
   settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - errname
     - errorlint
     - gocritic
     - gocyclo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - errorlint
     - gocritic
     - gocyclo
     - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - gosec
     - govet
     - ineffassign
+    - intrange
     - lll
     - misspell
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - lll
     - misspell
     - nolintlint
+    - perfsprint
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - wastedassign
   settings:
     errcheck:
       check-type-assertions: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - lll
     - misspell
     - nolintlint
+    - prealloc
     - revive
     - staticcheck
     - testifylint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - unparam
     - unused
     - wastedassign
+    - whitespace
   settings:
     errcheck:
       check-type-assertions: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - prealloc
     - revive
     - staticcheck
+    - tagliatelle
     - testifylint
     - unconvert
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,10 +26,10 @@ linters:
     - nolintlint
     - revive
     - staticcheck
+    - testifylint
     - unconvert
     - unparam
     - unused
-    - testifylint
   settings:
     errcheck:
       check-type-assertions: false

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 GOBIN ?= $$(go env GOPATH)/bin
+MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \;)
 
 .PHONY: lint
-lint:
-	golangci-lint run --build-tags=vfsintegration
+lint: $(addprefix lint/,$(MODULES))
+lint/%:
+	@echo "Running golangci-lint in $*/"
+	@cd $* && golangci-lint run --build-tags=vfsintegration
 
 .PHONY: install-go-test-coverage
 install-go-test-coverage:

--- a/backend/azure/client_integration_test.go
+++ b/backend/azure/client_integration_test.go
@@ -206,8 +206,9 @@ func (s *ClientIntegrationTestSuite) TestProperties_NonExistentFile() {
 	s.Require().NoError(err, "Env variables (AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCESS_KEY) should contain valid azure account credentials")
 
 	_, err = client.Properties(f.Location().URI(), f.Path())
-	s.Require().Error(err, "The file does not exist so we expect an error")
-	s.Equal(404, err.(*azcore.ResponseError).StatusCode)
+	var rerr *azcore.ResponseError
+	s.Require().ErrorAs(err, &rerr, "The file does not exist so we expect an error")
+	s.Equal(404, rerr.StatusCode)
 }
 
 func (s *ClientIntegrationTestSuite) TestDelete_NonExistentFile() {

--- a/backend/azure/file_test.go
+++ b/backend/azure/file_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/c2fo/vfs/v7/utils"
 )
 
-var blobNotFoundErr = &azcore.ResponseError{ErrorCode: string(bloberror.BlobNotFound)}
+var errBlobNotFound = &azcore.ResponseError{ErrorCode: string(bloberror.BlobNotFound)}
 
 type FileTestSuite struct {
 	suite.Suite
@@ -43,7 +43,7 @@ func (s *FileTestSuite) TestClose_FlushTempFile() {
 	fs := NewFileSystem(WithClient(client))
 	f, _ := fs.NewFile("test-container", "/foo.txt")
 
-	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, blobNotFoundErr)
+	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, errBlobNotFound)
 	client.EXPECT().Upload(mock.Anything, mock.Anything, "").Return(nil)
 	_, err := f.Write([]byte("Hello, World!"))
 	s.Require().NoError(err)
@@ -127,7 +127,7 @@ func (s *FileTestSuite) TestExists_NonExistentFile() {
 
 	f, err := fs.NewFile("test-container", "/foo.txt")
 	s.Require().NoError(err, "The path is valid so no error should be returned")
-	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, blobNotFoundErr)
+	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, errBlobNotFound)
 	exists, err := f.Exists()
 	s.Require().NoError(err, "no error is returned when the file does not exist")
 	s.False(exists)
@@ -137,7 +137,7 @@ func (s *FileTestSuite) TestCloseWithContentType() {
 	client := mocks.NewClient(s.T())
 	fs := NewFileSystem(WithClient(client))
 	f, _ := fs.NewFile("test-container", "/foo.txt", newfile.WithContentType("text/plain"))
-	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, blobNotFoundErr)
+	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, errBlobNotFound)
 	client.EXPECT().Upload(mock.Anything, mock.Anything, "text/plain").Return(nil)
 	_, _ = f.Write([]byte("Hello, World!"))
 	s.Require().NoError(f.Close())
@@ -346,7 +346,7 @@ func (s *FileTestSuite) TestTouchWithContentType() {
 
 	f, err := fs.NewFile("test-container", "/foo.txt", newfile.WithContentType("text/plain"))
 	s.Require().NoError(err, "The path is valid so no error should be returned")
-	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, blobNotFoundErr)
+	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, errBlobNotFound)
 	client.EXPECT().Upload(mock.Anything, mock.Anything, "text/plain").Return(nil)
 	s.Require().NoError(f.Touch())
 }
@@ -396,7 +396,7 @@ func (s *FileTestSuite) TestCheckTempFile_FileDoesNotExist() {
 	s.NotNil(azureFile)
 
 	s.Nil(azureFile.tempFile, "No calls to checkTempFile have occurred so we expect tempFile to be nil")
-	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, blobNotFoundErr)
+	client.EXPECT().Properties("test-container", "/foo.txt").Return(nil, errBlobNotFound)
 	err = azureFile.checkTempFile()
 	s.Require().NoError(err, "Check temp file should create a local temp file so no error is expected")
 	s.NotNil(azureFile.tempFile, "After the call to checkTempFile we should have a non-nil tempFile")

--- a/backend/azure/location.go
+++ b/backend/azure/location.go
@@ -37,13 +37,13 @@ func (l *Location) List() ([]string, error) {
 		return nil, err
 	}
 
-	var ret []string
-	for _, item := range list {
-		ret = append(ret, path.Base(item))
+	if len(list) == 0 {
+		return []string{}, nil
 	}
 
-	if len(ret) == 0 {
-		return []string{}, nil
+	ret := make([]string, len(list))
+	for i, item := range list {
+		ret[i] = path.Base(item)
 	}
 
 	return ret, nil

--- a/backend/azure/token_test.go
+++ b/backend/azure/token_test.go
@@ -1,7 +1,6 @@
 package azure
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -55,9 +54,9 @@ func TestDefaultTokenCredentialFactory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, os.Setenv("AZURE_TENANT_ID", tt.envTenantID))
-			require.NoError(t, os.Setenv("AZURE_CLIENT_ID", tt.envClientID))
-			require.NoError(t, os.Setenv("AZURE_CLIENT_SECRET", tt.envClientSecret))
+			t.Setenv("AZURE_TENANT_ID", tt.envTenantID)
+			t.Setenv("AZURE_CLIENT_ID", tt.envClientID)
+			t.Setenv("AZURE_CLIENT_SECRET", tt.envClientSecret)
 			cred, err := DefaultTokenCredentialFactory(tt.tenantID, tt.clientID, tt.clientSecret)
 			if tt.expectError {
 				require.Error(t, err)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -41,8 +41,8 @@ func Backend(name string) vfs.FileSystem {
 
 // RegisteredBackends returns an array of backend names
 func RegisteredBackends() []string {
-	var f []string
 	mmu.RLock()
+	f := make([]string, 0, len(m))
 	for k := range m {
 		f = append(f, k)
 	}

--- a/backend/ftp/dataconn.go
+++ b/backend/ftp/dataconn.go
@@ -25,7 +25,7 @@ type dataConn struct {
 // in a single op connection.
 func (dc *dataConn) Delete(path string) error {
 	if dc.mode != types.SingleOp {
-		return singleOpInvalidDataconnType
+		return errDataconnSingleOpInvalid
 	}
 	return dc.c.Delete(path)
 }
@@ -35,7 +35,7 @@ func (dc *dataConn) Delete(path string) error {
 // in a single op connection.
 func (dc *dataConn) GetEntry(p string) (*_ftp.Entry, error) {
 	if dc.mode != types.SingleOp {
-		return nil, singleOpInvalidDataconnType
+		return nil, errDataconnSingleOpInvalid
 	}
 	return dc.c.GetEntry(p)
 }
@@ -43,7 +43,7 @@ func (dc *dataConn) GetEntry(p string) (*_ftp.Entry, error) {
 // List conducts an FTP list for the given path. Only allowed in a single op connection.
 func (dc *dataConn) List(p string) ([]*_ftp.Entry, error) {
 	if dc.mode != types.SingleOp {
-		return nil, singleOpInvalidDataconnType
+		return nil, errDataconnSingleOpInvalid
 	}
 	return dc.c.List(p)
 }
@@ -52,7 +52,7 @@ func (dc *dataConn) List(p string) ([]*_ftp.Entry, error) {
 // Only allowed in a single op connection.
 func (dc *dataConn) MakeDir(path string) error {
 	if dc.mode != types.SingleOp {
-		return singleOpInvalidDataconnType
+		return errDataconnSingleOpInvalid
 	}
 	return dc.c.MakeDir(path)
 }
@@ -61,7 +61,7 @@ func (dc *dataConn) MakeDir(path string) error {
 // to the name specified at to. Only allowed in a single op connection.
 func (dc *dataConn) Rename(from, to string) error {
 	if dc.mode != types.SingleOp {
-		return singleOpInvalidDataconnType
+		return errDataconnSingleOpInvalid
 	}
 	return dc.c.Rename(from, to)
 }
@@ -77,7 +77,7 @@ func (dc *dataConn) IsSetTimeSupported() bool {
 // in single op mode.
 func (dc *dataConn) SetTime(path string, t time.Time) error {
 	if dc.mode != types.SingleOp {
-		return singleOpInvalidDataconnType
+		return errDataconnSingleOpInvalid
 	}
 	return dc.c.SetTime(path, t)
 }
@@ -95,7 +95,7 @@ func (dc *dataConn) Mode() types.OpenType {
 // Read will read bytes from the DataConn open file to the given buffer. Only allowed in an open read DataConn
 func (dc *dataConn) Read(buf []byte) (int, error) {
 	if dc.mode != types.OpenRead {
-		return 0, readInvalidDataconnType
+		return 0, errDataconnReadInvalid
 	}
 	return dc.R.Read(buf)
 }
@@ -103,7 +103,7 @@ func (dc *dataConn) Read(buf []byte) (int, error) {
 // Write will write bytes to the DataConn open file.
 func (dc *dataConn) Write(data []byte) (int, error) {
 	if dc.mode != types.OpenWrite {
-		return 0, writeInvalidDataconnType
+		return 0, errDataconnWriteInvalid
 	}
 	return dc.W.Write(data)
 }

--- a/backend/ftp/errors.go
+++ b/backend/ftp/errors.go
@@ -1,9 +1,9 @@
 package ftp
 
-type dataConnErr string
+type dataConnError string
 
-func (e dataConnErr) Error() string { return string(e) }
+func (e dataConnError) Error() string { return string(e) }
 
-const singleOpInvalidDataconnType = dataConnErr("dataconn must be open for single op mode to conduct a single op action")
-const readInvalidDataconnType = dataConnErr("dataconn must be open for read mode to conduct a read")
-const writeInvalidDataconnType = dataConnErr("dataconn must be open for write mode to conduct a write")
+const errDataconnSingleOpInvalid = dataConnError("dataconn must be open for single op mode to conduct a single op action")
+const errDataconnReadInvalid = dataConnError("dataconn must be open for read mode to conduct a read")
+const errDataconnWriteInvalid = dataConnError("dataconn must be open for write mode to conduct a write")

--- a/backend/ftp/errors_test.go
+++ b/backend/ftp/errors_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestDataConnErr_Error(t *testing.T) {
 	tests := []struct {
-		err      dataConnErr
+		err      dataConnError
 		expected string
 	}{
-		{singleOpInvalidDataconnType, "dataconn must be open for single op mode to conduct a single op action"},
-		{readInvalidDataconnType, "dataconn must be open for read mode to conduct a read"},
-		{writeInvalidDataconnType, "dataconn must be open for write mode to conduct a write"},
+		{errDataconnSingleOpInvalid, "dataconn must be open for single op mode to conduct a single op action"},
+		{errDataconnReadInvalid, "dataconn must be open for read mode to conduct a read"},
+		{errDataconnWriteInvalid, "dataconn must be open for write mode to conduct a write"},
 	}
 
 	for _, tt := range tests {

--- a/backend/ftp/file.go
+++ b/backend/ftp/file.go
@@ -57,7 +57,7 @@ func (f *File) stat(ctx context.Context) (*_ftp.Entry, error) {
 	if dc.IsTimePreciseInList() {
 		entry, err := dc.GetEntry(f.Path())
 		if err != nil {
-			if strings.HasPrefix(err.Error(), fmt.Sprintf("%d", _ftp.StatusFileUnavailable)) {
+			if strings.HasPrefix(err.Error(), strconv.Itoa(_ftp.StatusFileUnavailable)) {
 				return nil, os.ErrNotExist
 			}
 			return nil, err
@@ -66,7 +66,7 @@ func (f *File) stat(ctx context.Context) (*_ftp.Entry, error) {
 	} else {
 		entries, err := dc.List(f.Path())
 		if err != nil {
-			if strings.HasPrefix(err.Error(), fmt.Sprintf("%d", _ftp.StatusFileUnavailable)) {
+			if strings.HasPrefix(err.Error(), strconv.Itoa(_ftp.StatusFileUnavailable)) {
 				return nil, os.ErrNotExist
 			}
 			return nil, err

--- a/backend/ftp/location.go
+++ b/backend/ftp/location.go
@@ -3,9 +3,9 @@ package ftp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	_ftp "github.com/jlaffaye/ftp"
@@ -35,7 +35,7 @@ func (l *Location) List() ([]string, error) {
 
 	entries, err := dc.List(l.Path())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), fmt.Sprintf("%d", _ftp.StatusFileUnavailable)) {
+		if strings.HasPrefix(err.Error(), strconv.Itoa(_ftp.StatusFileUnavailable)) {
 			// in this case the directory does not exist
 			return filenames, nil
 		}
@@ -95,7 +95,7 @@ func (l *Location) ListByPrefix(prefix string) ([]string, error) {
 	entries, err := dc.List(fullpath)
 	if err != nil {
 		// fullpath does not exist, is not an error here
-		if strings.HasPrefix(err.Error(), fmt.Sprintf("%d", _ftp.StatusFileUnavailable)) {
+		if strings.HasPrefix(err.Error(), strconv.Itoa(_ftp.StatusFileUnavailable)) {
 			// in this case the directory does not exist
 			return []string{}, nil
 		}
@@ -161,7 +161,7 @@ func (l *Location) Exists() (bool, error) {
 
 	entries, err := dc.List(parentDir)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), fmt.Sprintf("%d", _ftp.StatusFileUnavailable)) {
+		if strings.HasPrefix(err.Error(), strconv.Itoa(_ftp.StatusFileUnavailable)) {
 			// in this case the directory does not exist
 			return false, nil
 		}

--- a/backend/ftp/location.go
+++ b/backend/ftp/location.go
@@ -72,7 +72,7 @@ func (l *Location) ListByPrefix(prefix string) ([]string, error) {
 	//   loc, _ := fs.NewLocation("user@host:21", "/some/path/")
 	//   loc.ListByPrefix("subdir/prefix")
 	// the location fullpath should resolve to be "/some/path/subdir/" while the prefix would be "prefix".
-	baseprefix := ""
+	var baseprefix string
 	if prefix == "." {
 		// for prefix of ".", it is necessary to manually set baseprefix as "." and
 		// add trailing slash since path.Join thinks that "." is a directory

--- a/backend/gs/file_test.go
+++ b/backend/gs/file_test.go
@@ -339,7 +339,7 @@ func (ts *fileTestSuite) TestMoveAndCopy() {
 
 	testCases := TestCases{}
 
-	for idx := 0; idx <= (1<<3)-1; idx++ {
+	for idx := range 1 << 3 {
 		testCases = append(testCases, TestCase{
 			move:       (idx & (1 << 0)) != 0,
 			readFirst:  (idx & (1 << 1)) != 0,
@@ -443,7 +443,7 @@ func (ts *fileTestSuite) TestMoveAndCopyBuffered() {
 	type TestCases []TestCase
 	testCases := TestCases{}
 
-	for idx := 0; idx <= (1<<3)-1; idx++ {
+	for idx := range 1 << 3 {
 		testCases = append(testCases, TestCase{
 			move:       (idx & (1 << 0)) != 0,
 			readFirst:  (idx & (1 << 1)) != 0,

--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -67,7 +67,7 @@ func (l *Location) ListByPrefix(filenamePrefix string) ([]string, error) {
 	for {
 		objAttrs, err := it.Next()
 		if err != nil {
-			if err == iterator.Done {
+			if errors.Is(err, iterator.Done) {
 				break
 			}
 			return nil, err

--- a/backend/gs/location_test.go
+++ b/backend/gs/location_test.go
@@ -30,7 +30,7 @@ func (lt *locationTestSuite) TestList() {
 	var createObjects func(prefix string, level int, levels int)
 	createObjects = func(prefix string, level int, levels int) {
 		objectPrefixes = append(objectPrefixes, prefix)
-		for idx := 0; idx < fileCount; idx++ {
+		for idx := range fileCount {
 			objectBaseName := fmt.Sprintf("f%d.txt", idx)
 			objectName := fmt.Sprintf("%s%s", prefix, objectBaseName)
 			objectNames = append(objectNames, objectName)
@@ -46,7 +46,7 @@ func (lt *locationTestSuite) TestList() {
 			})
 		}
 		if levels > 0 {
-			for idx := 0; idx < dirCount; idx++ {
+			for idx := range dirCount {
 				createObjects(fmt.Sprintf("%sd%d/", prefix, idx), level+1, levels-1)
 			}
 		}

--- a/backend/gs/options.go
+++ b/backend/gs/options.go
@@ -9,7 +9,7 @@ type Options struct {
 	APIKey         string   `json:"apiKey,omitempty"`
 	CredentialFile string   `json:"credentialFilePath,omitempty"`
 	Endpoint       string   `json:"endpoint,omitempty"`
-	Scopes         []string `json:"WithoutAuthentication,omitempty"`
+	Scopes         []string `json:"withoutAuthentication,omitempty"`
 	FileBufferSize int      `json:"fileBufferSize,omitempty"` // Buffer Size In Bytes Used with utils.TouchCopyBuffered
 }
 

--- a/backend/helpers.go
+++ b/backend/helpers.go
@@ -16,7 +16,7 @@ func ValidateCopySeekPosition(f vfs.File) error {
 		return fmt.Errorf("failed to determine current cursor offset: %w", err)
 	}
 	if offset != 0 {
-		return vfs.CopyToNotPossible
+		return vfs.ErrCopyToNotPossible
 	}
 
 	return nil

--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -446,9 +446,7 @@ func (f *File) Delete(_ ...options.DeleteOption) error {
 			// casting a file to the object's "i" interface
 			file := thisObj.i.(*memFile)
 			file.exists = false
-			file = nil
 			thisObj.i = nil
-			thisObj = nil
 			// setting that key to nil so it truly no longer lives on this system
 			delete(mapRef[loc.Authority().String()], str)
 		}

--- a/backend/mem/file_test.go
+++ b/backend/mem/file_test.go
@@ -360,8 +360,7 @@ func (s *memFileTest) TestCopyToLocationOS() {
 	s.Require().NoError(s.testFile.Close(), "unexpected error closing file")
 
 	var osFile vfs.File
-	dir, err := os.MkdirTemp("", "osDir")
-	s.Require().NoError(err)
+	dir := s.T().TempDir()
 	osFileName := filepath.Join(dir, "osFile.txt")
 
 	osFile, err = backend.Backend(_os.Scheme).NewFile("", osFileName)
@@ -392,8 +391,6 @@ func (s *memFileTest) TestCopyToLocationOS() {
 	s.Require().NoError(err, "unexpected read error")
 	s.Equal(readSlice2, readSlice) // both reads should be the same
 	s.Require().NoError(copiedFile.Close())
-	cleanErr := os.RemoveAll(dir) // clean up
-	s.Require().NoError(cleanErr, "unexpected error cleaning up osFiles")
 }
 
 // TestCopyToFile tests "CopyToFile()" between two files both in the in-memory FileSystem
@@ -426,8 +423,7 @@ func (s *memFileTest) TestCopyToFileOS() {
 	expectedText := "Hello World!"
 	var osFile vfs.File
 	var err error
-	dir, err := os.MkdirTemp("", "osDir")
-	s.Require().NoError(err)
+	dir := s.T().TempDir()
 	osFileName := filepath.Join(dir, "osFile.txt")
 
 	osFile, err = backend.Backend(_os.Scheme).NewFile("", osFileName)

--- a/backend/mem/location.go
+++ b/backend/mem/location.go
@@ -215,9 +215,7 @@ func (l *Location) DeleteFile(relFilePath string, _ ...options.DeleteOption) err
 		if thisObj, ok2 := mapRef[vol][fullPath]; ok2 {
 			file := thisObj.i.(*memFile)
 			file.exists = false
-			file = nil
 			thisObj.i = nil
-			thisObj = nil
 			mapRef[vol][fullPath] = nil // setting that key to nil so it truly no longer lives on this system
 			delete(mapRef[vol], fullPath)
 			return nil

--- a/backend/os/file.go
+++ b/backend/os/file.go
@@ -245,8 +245,9 @@ func (f *File) MoveToFile(file vfs.File) error {
 func safeOsRename(srcName, dstName string) error {
 	err := os.Rename(srcName, dstName)
 	if err != nil {
-		e, ok := err.(*os.LinkError)
-		if ok && (e.Err.Error() == osCrossDeviceLinkError || (runtime.GOOS == "windows" && e.Err.Error() == "Access is denied.")) {
+		var e *os.LinkError
+		if errors.As(err, &e) && (e.Err.Error() == osCrossDeviceLinkError ||
+			(runtime.GOOS == "windows" && e.Err.Error() == "Access is denied.")) {
 			// do cross-device renaming
 			if err := osCopy(srcName, dstName); err != nil {
 				return err

--- a/backend/os/file_test.go
+++ b/backend/os/file_test.go
@@ -2,7 +2,6 @@ package os
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -656,14 +655,14 @@ func (s *osFileTest) TestPath() {
 func (s *osFileTest) TestURI() {
 	file, err := s.tmploc.NewFile("some/file/test.txt")
 	s.Require().NoError(err)
-	expected := fmt.Sprintf("file://%s", filepath.ToSlash(filepath.Join(osLocationPath(s.tmploc), "some", "file", "test.txt")))
+	expected := "file://" + filepath.ToSlash(filepath.Join(osLocationPath(s.tmploc), "some", "file", "test.txt"))
 	s.Equal(expected, file.URI(), "%s does not match %s", file.URI(), expected)
 }
 
 func (s *osFileTest) TestStringer() {
 	file, err := s.tmploc.NewFile("some/file/test.txt")
 	s.Require().NoError(err)
-	s.Equal(fmt.Sprintf("file://%s", filepath.ToSlash(filepath.Join(osLocationPath(s.tmploc), "some", "file", "test.txt"))), file.String())
+	s.Equal("file://"+filepath.ToSlash(filepath.Join(osLocationPath(s.tmploc), "some", "file", "test.txt")), file.String())
 }
 
 //nolint:staticcheck // deprecated method test

--- a/backend/os/file_test.go
+++ b/backend/os/file_test.go
@@ -33,16 +33,12 @@ type osFileTest struct {
 func (s *osFileTest) SetupSuite() {
 	fs := &FileSystem{}
 	s.fileSystem = fs
-	dir, err := os.MkdirTemp("", "os_file_test")
+	dir := s.T().TempDir()
 	dir = utils.EnsureTrailingSlash(dir)
-	s.Require().NoError(err)
+	var err error
 	s.tmploc, err = fs.NewLocation("", dir)
 	s.Require().NoError(err)
 	setupTestFiles(s.tmploc)
-}
-
-func (s *osFileTest) TearDownSuite() {
-	teardownTestFiles(s.tmploc)
 }
 
 func (s *osFileTest) SetupTest() {
@@ -260,17 +256,11 @@ func (s *osFileTest) TestCopyToLocationIgnoreExtraSeparator() {
 
 func (s *osFileTest) TestMoveToLocation() {
 	expectedText := "moved file"
-	dir, terr := os.MkdirTemp(filepath.Join(osLocationPath(s.tmploc), "test_files"), "example")
-	s.Require().NoError(terr)
+	dir := s.T().TempDir()
 
 	origFileName := filepath.Join(dir, "test_files", "move.txt")
 	file, nerr := s.fileSystem.NewFile("", origFileName)
 	s.Require().NoError(nerr)
-
-	defer func() {
-		err := os.RemoveAll(dir)
-		s.Require().NoError(err, "remove all error not expected")
-	}()
 
 	_, werr := file.Write([]byte(expectedText))
 	s.Require().NoError(werr, "write error not expected")
@@ -325,12 +315,7 @@ func (s *osFileTest) TestMoveToLocation() {
 }
 
 func (s *osFileTest) TestSafeOsRename() {
-	dir, err := os.MkdirTemp(filepath.Join(osLocationPath(s.tmploc), "test_files"), "example")
-	s.Require().NoError(err)
-	defer func() {
-		err := os.RemoveAll(dir)
-		s.Require().NoError(err, "remove all error not expected")
-	}()
+	dir := s.T().TempDir()
 
 	// TODO: I haven't figured out a way to test safeOsRename since setting up the scenario is
 	//     very os-dependent so here I will actually only ensure non-"invalid cross-device link"
@@ -366,12 +351,7 @@ func (s *osFileTest) TestSafeOsRename() {
 }
 
 func (s *osFileTest) TestOsCopy() {
-	dir, err := os.MkdirTemp(filepath.Join(osLocationPath(s.tmploc), "test_files"), "example")
-	s.Require().NoError(err)
-	defer func() {
-		err := os.RemoveAll(dir)
-		s.Require().NoError(err, "remove all error not expected")
-	}()
+	dir := s.T().TempDir()
 
 	file1, err := s.fileSystem.NewFile("", path.Join(dir, "original.txt"))
 	s.Require().NoError(err)
@@ -398,19 +378,13 @@ func (s *osFileTest) TestOsCopy() {
 }
 
 func (s *osFileTest) TestMoveToFile() {
-	dir, terr := os.MkdirTemp(filepath.Join(osLocationPath(s.tmploc), "test_files"), "example")
-	s.Require().NoError(terr)
+	dir := s.T().TempDir()
 
 	file1, err := s.fileSystem.NewFile("", path.Join(dir, "original.txt"))
 	s.Require().NoError(err)
 
 	file2, err := s.fileSystem.NewFile("", path.Join(dir, "move.txt"))
 	s.Require().NoError(err)
-
-	defer func() {
-		err := os.RemoveAll(dir)
-		s.Require().NoError(err, "remove all error not expected")
-	}()
 
 	text := "original file"
 	_, werr := file1.Write([]byte(text))
@@ -733,19 +707,11 @@ func setupTestFiles(baseLoc vfs.Location) {
 	writeStringFile(baseLoc, "test_files/subdir/test.txt", `hello world too`)
 }
 
-func teardownTestFiles(baseLoc vfs.Location) {
-	err := os.RemoveAll(baseLoc.Path())
-	if err != nil {
-		panic(err)
-	}
-}
-
 func createDir(baseLoc vfs.Location, dirname string) {
 	dir := path.Join(baseLoc.Path(), dirname)
 	perm := os.FileMode(0755)
 	err := os.Mkdir(dir, perm)
 	if err != nil {
-		teardownTestFiles(baseLoc)
 		panic(err)
 	}
 }
@@ -754,17 +720,14 @@ func writeStringFile(baseLoc vfs.Location, filename, data string) {
 	file := path.Join(baseLoc.Path(), filename)
 	f, err := os.Create(file) //nolint:gosec
 	if err != nil {
-		teardownTestFiles(baseLoc)
 		panic(err)
 	}
 	_, err = f.WriteString(data)
 	if err != nil {
-		teardownTestFiles(baseLoc)
 		panic(err)
 	}
 	err = f.Close()
 	if err != nil {
-		teardownTestFiles(baseLoc)
 		panic(err)
 	}
 }

--- a/backend/os/location_test.go
+++ b/backend/os/location_test.go
@@ -26,16 +26,12 @@ type osLocationTest struct {
 
 func (s *osLocationTest) SetupSuite() {
 	fs := &FileSystem{}
-	dir, err := os.MkdirTemp("", "os_location_test")
+	dir := s.T().TempDir()
 	dir = utils.EnsureTrailingSlash(dir)
-	s.Require().NoError(err)
+	var err error
 	s.tmploc, err = fs.NewLocation("", dir)
 	s.Require().NoError(err)
 	setupTestFiles(s.tmploc)
-}
-
-func (s *osLocationTest) TearDownSuite() {
-	teardownTestFiles(s.tmploc)
 }
 
 func (s *osLocationTest) SetupTest() {

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -120,7 +120,7 @@ func (f *File) CopyToFile(file vfs.File) (err error) {
 	}()
 	// validate seek is at 0,0 before doing copy
 	if f.cursorPos != 0 {
-		return vfs.CopyToNotPossible
+		return vfs.ErrCopyToNotPossible
 	}
 
 	// if target is S3

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -590,13 +590,11 @@ func (ts *fileTestSuite) TestDeleteError() {
 }
 
 func (ts *fileTestSuite) TestDeleteWithAllVersionsOption() {
-	var versions []types.ObjectVersion
-	verIds := [...]string{"ver1", "ver2"}
-	for i := range verIds {
-		versions = append(versions, types.ObjectVersion{VersionId: &verIds[i]})
-	}
 	versOutput := s3.ListObjectVersionsOutput{
-		Versions: versions,
+		Versions: []types.ObjectVersion{
+			{VersionId: utils.Ptr("ver1")},
+			{VersionId: utils.Ptr("ver2")},
+		},
 	}
 	s3cliMock.On("ListObjectVersions", matchContext, mock.AnythingOfType("*s3.ListObjectVersionsInput")).Return(&versOutput, nil)
 	s3cliMock.On("DeleteObject", matchContext, mock.AnythingOfType("*s3.DeleteObjectInput")).Return(&s3.DeleteObjectOutput{}, nil).Times(3)
@@ -606,20 +604,18 @@ func (ts *fileTestSuite) TestDeleteWithAllVersionsOption() {
 }
 
 func (ts *fileTestSuite) TestDeleteWithAllVersionsOptionError() {
-	var versions []types.ObjectVersion
-	verIds := [...]string{"ver1", "ver2"}
-	for i := range verIds {
-		versions = append(versions, types.ObjectVersion{VersionId: &verIds[i]})
-	}
 	versOutput := s3.ListObjectVersionsOutput{
-		Versions: versions,
+		Versions: []types.ObjectVersion{
+			{VersionId: utils.Ptr("ver1")},
+			{VersionId: utils.Ptr("ver2")},
+		},
 	}
 	s3cliMock.On("ListObjectVersions", matchContext, mock.AnythingOfType("*s3.ListObjectVersionsInput")).
 		Return(&versOutput, nil)
 	key := utils.Ptr(utils.RemoveLeadingSlash(testFileName))
 	s3cliMock.On("DeleteObject", matchContext, &s3.DeleteObjectInput{Key: key, Bucket: &bucket}).
 		Return(&s3.DeleteObjectOutput{}, nil).Once()
-	s3cliMock.On("DeleteObject", matchContext, &s3.DeleteObjectInput{Key: key, Bucket: &bucket, VersionId: &verIds[0]}).
+	s3cliMock.On("DeleteObject", matchContext, &s3.DeleteObjectInput{Key: key, Bucket: &bucket, VersionId: utils.Ptr("ver1")}).
 		Return(nil, errors.New("something went wrong")).Once()
 
 	err := testFile.Delete(delete.WithAllVersions())

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -334,7 +335,7 @@ func (ts *fileTestSuite) TestGetCopyObject() {
 
 	// ensure spaces are properly encoded (or not)
 	for i, t := range tests {
-		ts.Run(fmt.Sprintf("%d", i), func() {
+		ts.Run(strconv.Itoa(i), func() {
 			sourceFile := &File{
 				location: &Location{
 					fileSystem: &FileSystem{

--- a/backend/s3/location_test.go
+++ b/backend/s3/location_test.go
@@ -316,13 +316,11 @@ func (lt *locationTestSuite) TestDeleteFile() {
 }
 
 func (lt *locationTestSuite) TestDeleteFileWithAllVersionsOption() {
-	var versions []types.ObjectVersion
-	verIds := [...]string{"ver1", "ver2"}
-	for i := range verIds {
-		versions = append(versions, types.ObjectVersion{VersionId: &verIds[i]})
-	}
 	versOutput := s3.ListObjectVersionsOutput{
-		Versions: versions,
+		Versions: []types.ObjectVersion{
+			{VersionId: utils.Ptr("ver1")},
+			{VersionId: utils.Ptr("ver2")},
+		},
 	}
 	lt.s3cliMock.On("ListObjectVersions", matchContext, mock.AnythingOfType("*s3.ListObjectVersionsInput")).Return(&versOutput, nil)
 	lt.s3cliMock.On("DeleteObject", matchContext, mock.AnythingOfType("*s3.DeleteObjectInput")).Return(&s3.DeleteObjectOutput{}, nil).Times(3)
@@ -342,10 +340,9 @@ func TestLocation(t *testing.T) {
 Helpers
 */
 func convertKeysToS3Objects(keys []string) []types.Object {
-	var objects []types.Object
-	for _, key := range keys {
-		object := types.Object{Key: aws.String(key)}
-		objects = append(objects, object)
+	objects := make([]types.Object, len(keys))
+	for i, key := range keys {
+		objects[i] = types.Object{Key: aws.String(key)}
 	}
 	return objects
 }

--- a/backend/s3/options.go
+++ b/backend/s3/options.go
@@ -18,7 +18,7 @@ type Options struct {
 	SecretAccessKey             string                `json:"secretAccessKey,omitempty"`
 	SessionToken                string                `json:"sessionToken,omitempty"`
 	Region                      string                `json:"region,omitempty"`
-	RoleARN                     string                `json:"roleARN,omitempty"`
+	RoleARN                     string                `json:"roleArn,omitempty"`
 	Endpoint                    string                `json:"endpoint,omitempty"`
 	ACL                         types.ObjectCannedACL `json:"acl,omitempty"`
 	ForcePathStyle              bool                  `json:"forcePathStyle,omitempty"`

--- a/backend/sftp/concurrency_test.go
+++ b/backend/sftp/concurrency_test.go
@@ -54,7 +54,7 @@ func (s *SFTPConcurrencyTestSuite) TestClientTypedNilHandling() {
 	s.Require().NoError(err)
 
 	// Multiple attempts should fail gracefully without panics
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		client, err := fs.Client(auth)
 		s.T().Logf("Attempt %d: client=%v, err=%v", i+1, client, err)
 		if err == nil {
@@ -83,7 +83,7 @@ func (s *SFTPConcurrencyTestSuite) TestConcurrentFailedConnections() {
 	panicChan := make(chan interface{}, numGoroutines)
 	errorChan := make(chan error, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -129,7 +129,7 @@ func (s *SFTPConcurrencyTestSuite) TestConcurrentFailedConnections() {
 // to ensure the filesystem remains stable and doesn't panic
 func (s *SFTPConcurrencyTestSuite) TestClientFailureRobustness() {
 	s.Run("Multiple failed connection attempts should not panic", func() {
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			s.Run(fmt.Sprintf("Attempt %d", i+1), func() {
 				// Create a new filesystem for each attempt to avoid state pollution
 				fs := NewFileSystem(WithOptions(Options{
@@ -143,7 +143,7 @@ func (s *SFTPConcurrencyTestSuite) TestClientFailureRobustness() {
 
 				// Test multiple client creation attempts that will fail
 				// This is where the typed nil issue would occur
-				for j := 0; j < 3; j++ {
+				for range 3 {
 					_, _ = fs.Client(auth) // This should fail but not panic
 				}
 
@@ -175,7 +175,7 @@ func (s *SFTPConcurrencyTestSuite) TestTimerCleanupRobustness() {
 	var wg sync.WaitGroup
 	panicChan := make(chan interface{}, numOperations)
 
-	for i := 0; i < numOperations; i++ {
+	for range numOperations {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/backend/sftp/concurrency_test.go
+++ b/backend/sftp/concurrency_test.go
@@ -104,13 +104,13 @@ func (s *SFTPConcurrencyTestSuite) TestConcurrentFailedConnections() {
 	close(errorChan)
 
 	// Collect any panics that occurred
-	var panics []interface{}
+	panics := make([]interface{}, 0, len(panicChan))
 	for panic := range panicChan {
 		panics = append(panics, panic)
 	}
 
 	// Collect errors
-	var errors []error
+	errors := make([]error, 0, len(errorChan))
 	for err := range errorChan {
 		errors = append(errors, err)
 	}
@@ -201,7 +201,7 @@ func (s *SFTPConcurrencyTestSuite) TestTimerCleanupRobustness() {
 	close(panicChan)
 
 	// Collect any panics that occurred
-	var panics []interface{}
+	panics := make([]interface{}, 0, len(panicChan))
 	for panic := range panicChan {
 		panics = append(panics, panic)
 	}

--- a/backend/sftp/file_test.go
+++ b/backend/sftp/file_test.go
@@ -729,7 +729,6 @@ func (ts *fileTestSuite) TestMoveToLocation() {
 	ts.Require().NoError(err, "Error shouldn't be returned from successful call to CopyToFile")
 
 	ts.Equal("sftp://user@host2.com:22/some/other/path.txt", newFile.URI(), "new file uri check")
-
 }
 
 func (ts *fileTestSuite) TestTouch() {

--- a/backend/sftp/location.go
+++ b/backend/sftp/location.go
@@ -34,7 +34,7 @@ func (l *Location) List() ([]string, error) {
 
 	fileinfos, err := client.ReadDir(l.Path())
 	if err != nil {
-		if err == os.ErrNotExist {
+		if errors.Is(err, os.ErrNotExist) {
 			return filenames, nil
 		}
 		return filenames, err
@@ -133,7 +133,7 @@ func (l *Location) Exists() (bool, error) {
 	defer l.fileSystem.connTimerStart()
 
 	info, err := client.Stat(l.Path())
-	if err != nil && err == os.ErrNotExist {
+	if err != nil && errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/backend/sftp/options.go
+++ b/backend/sftp/options.go
@@ -46,7 +46,7 @@ func (o *Options) GetFileMode() (*os.FileMode, error) {
 	// Convert the string to an unsigned integer, interpreting it as an octal value
 	parsed, err := strconv.ParseUint(*o.FilePermissions, 0, 32)
 	if err != nil {
-		return nil, fmt.Errorf("invalid file mode: %v", err)
+		return nil, fmt.Errorf("invalid file mode: %w", err)
 	}
 	return utils.Ptr(os.FileMode(parsed)), nil
 }

--- a/backend/sftp/options_test.go
+++ b/backend/sftp/options_test.go
@@ -31,9 +31,7 @@ type optionsSuite struct {
 }
 
 func (o *optionsSuite) SetupSuite() {
-	dir, err := os.MkdirTemp("", "sftp_options_test")
-	o.Require().NoError(err, "setting up sftp_options_test temp dir")
-	o.tmpdir = dir
+	o.tmpdir = o.T().TempDir()
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	o.Require().NoError(err)
@@ -44,10 +42,6 @@ func (o *optionsSuite) SetupSuite() {
 	keyFiles, err := setupKeyFiles(o.tmpdir)
 	o.Require().NoError(err)
 	o.keyFiles = *keyFiles
-}
-
-func (o *optionsSuite) TearDownSuite() {
-	o.Require().NoError(os.RemoveAll(o.tmpdir), "cleaning up after test")
 }
 
 type foundFileTest struct {

--- a/backend/testsuite/backend_integration_test.go
+++ b/backend/testsuite/backend_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -71,7 +72,7 @@ func (s *vfsTestSuite) SetupSuite() {
 		case "ftp":
 			s.testLocations[l.FileSystem().Scheme()] = l.(*ftp.Location)
 		default:
-			panic(fmt.Sprintf("unknown scheme: %s", l.FileSystem().Scheme()))
+			panic("unknown scheme: " + l.FileSystem().Scheme())
 		}
 	}
 }
@@ -266,7 +267,7 @@ func (s *vfsTestSuite) Location(baseLoc vfs.Location) {
 	//
 	// URI's for locations must always end with a separator character.
 	s.True(strings.HasSuffix(cdTestLoc.URI(), "locTestSrc/chdirTest/l1dir1/l2dir2/"), "should end with dot dirs resolved")
-	prefix := fmt.Sprintf("%s://", cdTestLoc.FileSystem().Scheme())
+	prefix := cdTestLoc.FileSystem().Scheme() + "://"
 	s.True(strings.HasPrefix(cdTestLoc.URI(), prefix), "should start with schema and abs slash")
 
 	/* Exists returns boolean if the location exists on the file system. Returns an error if any.
@@ -749,7 +750,7 @@ func (s *vfsTestSuite) File(baseLoc vfs.Location) {
 		}
 
 		for i, test := range tests {
-			s.Run(fmt.Sprintf("%d", i), func() {
+			s.Run(strconv.Itoa(i), func() {
 				// setup src
 				srcSpaces, err := srcLoc.NewFile(path.Join(test.Path, test.Filename))
 				s.Require().NoError(err)

--- a/backend/testsuite/io_integration_test.go
+++ b/backend/testsuite/io_integration_test.go
@@ -139,8 +139,7 @@ type ioTestSuite struct {
 The following example shows how to setup the test suite to run against a local directory for unix file baseline
 
 // setup local tests
-osTemp, err := os.MkdirTemp("", "vfs-io-test")
-s.Require().NoError(err)
+osTemp := s.T().TempDir()
 
 // add baseline OS test
 loc := osTemp + "/"

--- a/backend/testsuite/io_integration_test.go
+++ b/backend/testsuite/io_integration_test.go
@@ -4,7 +4,6 @@ package testsuite
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -194,7 +193,7 @@ func (s *ioTestSuite) SetupSuite() {
 			case "ftp":
 				s.testLocations[l.FileSystem().Scheme()] = l.(*ftp.Location)
 			default:
-				panic(fmt.Sprintf("unknown scheme: %s", l.FileSystem().Scheme()))
+				panic("unknown scheme: " + l.FileSystem().Scheme())
 			}
 		}
 	}

--- a/contrib/lockfile/README.md
+++ b/contrib/lockfile/README.md
@@ -219,7 +219,7 @@ When using S3, be aware of its eventual consistency model:
 
    // Implement retry logic with exponential backoff
    var err error
-   for i := 0; i < 3; i++ {
+   for i := range 3 {
        if err = lock.Acquire(); err == nil {
            break
        }

--- a/contrib/lockfile/lockfile.go
+++ b/contrib/lockfile/lockfile.go
@@ -38,11 +38,11 @@ var (
 
 // Metadata contains information about the current lock holder.
 type Metadata struct {
-	CreatedAt time.Time     `json:"created_at"`
+	CreatedAt time.Time     `json:"createdAt"`
 	TTL       time.Duration `json:"ttl"`
 	Hostname  string        `json:"hostname"`
 	PID       int           `json:"pid"`
-	OwnerID   string        `json:"owner_id,omitempty"`
+	OwnerID   string        `json:"ownerId,omitempty"`
 }
 
 // StaleHandler is a function that is called when a lock is stale.

--- a/contrib/vfsevents/vfsevents_test.go
+++ b/contrib/vfsevents/vfsevents_test.go
@@ -152,7 +152,7 @@ func (s *VfseventsTestSuite) TestWatcherError() {
 			Cause:   nil,
 		}
 
-		s.Nil(errNoCause.Unwrap())
+		s.Require().NoError(errNoCause.Unwrap())
 	})
 }
 
@@ -171,7 +171,7 @@ func (s *VfseventsTestSuite) TestNewWatcherError() {
 
 		s.Equal(ErrorTypeAuth, err.Type)
 		s.Equal("authentication failed", err.Message)
-		s.Nil(err.Cause)
+		s.Require().NoError(err.Unwrap())
 	})
 }
 
@@ -182,7 +182,7 @@ func (s *VfseventsTestSuite) TestDefaultRetryConfig() {
 	s.Equal(3, config.MaxRetries)
 	s.Equal(time.Second, config.InitialBackoff)
 	s.Equal(30*time.Second, config.MaxBackoff)
-	s.Equal(2.0, config.BackoffFactor)
+	s.InEpsilon(2.0, config.BackoffFactor, 0.001)
 	s.Empty(config.RetryableErrors)
 }
 
@@ -602,9 +602,9 @@ func (s *VfseventsTestSuite) TestWatcherMetrics() {
 			MemoryUsage:     1024 * 1024,
 		}
 
-		s.Equal(10.5, metrics.EventsPerSecond)
+		s.InEpsilon(10.5, metrics.EventsPerSecond, 0.001)
 		s.Equal(100*time.Millisecond, metrics.AverageLatency)
-		s.Equal(0.05, metrics.ErrorRate)
+		s.InEpsilon(0.05, metrics.ErrorRate, 0.001)
 		s.Equal(uint64(1024*1024), metrics.MemoryUsage)
 	})
 }

--- a/contrib/vfsevents/watchers/fsnotify/debounce_test.go
+++ b/contrib/vfsevents/watchers/fsnotify/debounce_test.go
@@ -194,7 +194,7 @@ func testMemoryLeakPrevention(t *testing.T, location vfs.Location, tempDir strin
 
 	// Create multiple files to populate the pending events map
 	// Use a longer debounce time to ensure events stay pending
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		testFile := filepath.Join(tempDir, fmt.Sprintf("leak_test_%d.txt", i))
 		err = os.WriteFile(testFile, []byte("content"), 0600)
 		require.NoError(t, err)

--- a/contrib/vfsevents/watchers/fsnotify/debounce_test.go
+++ b/contrib/vfsevents/watchers/fsnotify/debounce_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 func TestDebouncing(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "fsnotify_debounce_*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	location, err := vfssimple.NewLocation(fileURL(tempDir))
 	require.NoError(t, err)
@@ -318,9 +316,7 @@ eventLoop:
 }
 
 func TestDebouncingEdgeCases(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "fsnotify_debounce_edge_*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	location, err := vfssimple.NewLocation(fileURL(tempDir))
 	require.NoError(t, err)

--- a/contrib/vfsevents/watchers/fsnotify/event_analysis_test.go
+++ b/contrib/vfsevents/watchers/fsnotify/event_analysis_test.go
@@ -18,9 +18,7 @@ import (
 // TestEventAnalysis analyzes different file writing patterns to understand
 // the underlying filesystem event sequences
 func TestEventAnalysis(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "fsnotify_event_analysis_*")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	location, err := vfssimple.NewLocation(fileURL(tempDir))
 	require.NoError(t, err)

--- a/contrib/vfsevents/watchers/fsnotify/fsnotify.go
+++ b/contrib/vfsevents/watchers/fsnotify/fsnotify.go
@@ -9,6 +9,7 @@ package fsnotify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,7 +95,7 @@ func WithDebounce(duration time.Duration) Option {
 // The location must be a local filesystem path (file:// scheme).
 func NewFSNotifyWatcher(location vfs.Location, opts ...Option) (*FSNotifyWatcher, error) {
 	if location == nil {
-		return nil, fmt.Errorf("location cannot be nil")
+		return nil, errors.New("location cannot be nil")
 	}
 
 	// Verify this is a local filesystem location FIRST
@@ -140,7 +141,7 @@ func (w *FSNotifyWatcher) Start(
 	defer w.mu.Unlock()
 
 	if w.cancel != nil {
-		return fmt.Errorf("fsnotify watcher is already running")
+		return errors.New("fsnotify watcher is already running")
 	}
 
 	// Process start options
@@ -196,7 +197,7 @@ func (w *FSNotifyWatcher) Stop(opts ...vfsevents.StopOption) error {
 	defer w.mu.Unlock()
 
 	if w.cancel == nil {
-		return fmt.Errorf("fsnotify watcher is not running")
+		return errors.New("fsnotify watcher is not running")
 	}
 
 	// Process stop options

--- a/contrib/vfsevents/watchers/fsnotify/fsnotify_test.go
+++ b/contrib/vfsevents/watchers/fsnotify/fsnotify_test.go
@@ -60,9 +60,7 @@ type FSNotifyWatcherTestSuite struct {
 
 func (s *FSNotifyWatcherTestSuite) SetupTest() {
 	// Create a temporary directory for testing
-	var err error
-	s.tempDir, err = os.MkdirTemp("", "fsnotify_test_*")
-	s.Require().NoError(err)
+	s.tempDir = s.T().TempDir()
 }
 
 func (s *FSNotifyWatcherTestSuite) TearDownTest() {
@@ -70,13 +68,6 @@ func (s *FSNotifyWatcherTestSuite) TearDownTest() {
 	if s.watcher != nil {
 		_ = s.watcher.Stop() // Ignore error in test teardown
 		s.watcher = nil
-	}
-
-	// Clean up temporary directory
-	if s.tempDir != "" {
-		err := os.RemoveAll(s.tempDir)
-		s.Require().NoError(err)
-		s.tempDir = ""
 	}
 }
 

--- a/contrib/vfsevents/watchers/fsnotify/fsnotify_test.go
+++ b/contrib/vfsevents/watchers/fsnotify/fsnotify_test.go
@@ -161,7 +161,7 @@ func (s *FSNotifyWatcherTestSuite) TestStartAndStop() {
 			s.Equal(vfsevents.EventCreated, event.Type)
 			s.Equal("file://"+testFile, event.URI)
 		case err := <-errors:
-			s.Fail("Unexpected error: %v", err)
+			s.Require().NoError(err)
 		case <-time.After(getEventTimeout()):
 			s.Fail("Timeout waiting for create event")
 		}
@@ -514,7 +514,7 @@ eventLoop:
 			} else if s.isLogFileEvent(event.URI) {
 				logEventReceived = true
 				fmt.Printf("TEST DEBUG: Marking logEventReceived = true - THIS SHOULD NOT HAPPEN!\n")
-				s.Fail("Received unexpected event: %+v", event)
+				s.Fail("Received unexpected event", event)
 			} else {
 				fmt.Printf("TEST DEBUG: Received unexpected event (not test.txt or test.log): %+v\n", event)
 			}
@@ -556,7 +556,7 @@ func (s *FSNotifyWatcherTestSuite) checkForAdditionalEvents(events chan vfsevent
 		if s.isLogFileEvent(event2.URI) {
 			*logEventReceived = true
 			fmt.Printf("TEST DEBUG: Marking logEventReceived = true - THIS SHOULD NOT HAPPEN!\n")
-			s.Fail("Received unexpected event: %+v", event2)
+			s.Fail("Received unexpected event", event2)
 		}
 	case <-time.After(200 * time.Millisecond):
 		// No additional events, good

--- a/contrib/vfsevents/watchers/gcsevents/gcsevents.go
+++ b/contrib/vfsevents/watchers/gcsevents/gcsevents.go
@@ -4,7 +4,9 @@ package gcsevents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -97,10 +99,10 @@ func WithPubSubClient(client PubSubClient) Option {
 // "projects/{project}/subscriptions/{subscription}".
 func NewGCSWatcher(projectID, subscriptionID string, opts ...Option) (*GCSWatcher, error) {
 	if projectID == "" {
-		return nil, fmt.Errorf("projectID cannot be empty")
+		return nil, errors.New("projectID cannot be empty")
 	}
 	if subscriptionID == "" {
-		return nil, fmt.Errorf("subscription cannot be empty")
+		return nil, errors.New("subscription cannot be empty")
 	}
 
 	w := &GCSWatcher{}
@@ -133,7 +135,7 @@ func (w *GCSWatcher) Start(
 	defer w.mu.Unlock()
 
 	if w.cancel != nil {
-		return fmt.Errorf("GCS watcher is already running")
+		return errors.New("GCS watcher is already running")
 	}
 
 	// Process start options
@@ -282,7 +284,7 @@ func (w *GCSWatcher) receive(
 				"bucketName": gcsEvent.Bucket,
 				"object":     gcsEvent.Name,
 				"eventType":  eventType,
-				"generation": fmt.Sprintf("%d", gcsEvent.Generation),
+				"generation": strconv.FormatInt(gcsEvent.Generation, 10),
 			}
 
 			// Add overwroteGeneration if present (indicates this was an overwrite)
@@ -363,7 +365,7 @@ func (w *GCSWatcher) Stop(opts ...vfsevents.StopOption) error {
 	defer w.mu.Unlock()
 
 	if w.cancel == nil {
-		return fmt.Errorf("GCS watcher is not running")
+		return errors.New("GCS watcher is not running")
 	}
 
 	// Process stop options

--- a/contrib/vfsevents/watchers/gcsevents/gcsevents.go
+++ b/contrib/vfsevents/watchers/gcsevents/gcsevents.go
@@ -196,7 +196,7 @@ func (w *GCSWatcher) receiveWithRetry(
 	}
 
 	var lastErr error
-	for attempt := 0; attempt <= c.RetryConfig.MaxRetries; attempt++ {
+	for attempt := range c.RetryConfig.MaxRetries + 1 {
 		err := w.receive(ctx, handler, errHandler, status, c)
 
 		if err == nil {

--- a/contrib/vfsevents/watchers/gcsevents/gcsevents_test.go
+++ b/contrib/vfsevents/watchers/gcsevents/gcsevents_test.go
@@ -3,6 +3,7 @@ package gcsevents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -86,7 +87,7 @@ func (s *GCSWatcherTestSuite) TestStart() {
 		{
 			name: "Receive error",
 			setupMocks: func() {
-				s.pubsubClient.EXPECT().Receive(mock.Anything, mock.Anything).Return(fmt.Errorf("receive error")).Once()
+				s.pubsubClient.EXPECT().Receive(mock.Anything, mock.Anything).Return(errors.New("receive error")).Once()
 			},
 			wantErr: true,
 		},
@@ -191,7 +192,7 @@ func (s *GCSWatcherTestSuite) TestPoll() {
 			setupMocks: func() {
 				s.pubsubClient.EXPECT().
 					Receive(mock.Anything, mock.Anything).
-					Return(fmt.Errorf("receive error")).
+					Return(errors.New("receive error")).
 					Once()
 			},
 			wantErr: true,
@@ -265,7 +266,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 			},
 			setupMocks: func() {
 				s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
-					Return(fmt.Errorf("network error")).
+					Return(errors.New("network error")).
 					Once()
 			},
 			expectCalls:    1,
@@ -284,7 +285,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 			setupMocks: func() {
 				// First call fails with retryable error
 				s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
-					Return(fmt.Errorf("deadline exceeded")).
+					Return(errors.New("deadline exceeded")).
 					Once()
 
 				// Second call succeeds
@@ -324,7 +325,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 			},
 			setupMocks: func() {
 				s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
-					Return(fmt.Errorf("invalid credentials")).
+					Return(errors.New("invalid credentials")).
 					Once()
 			},
 			expectCalls:    1,
@@ -343,7 +344,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 			setupMocks: func() {
 				// All attempts fail with retryable error
 				s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
-					Return(fmt.Errorf("service unavailable")).
+					Return(errors.New("service unavailable")).
 					Times(3) // Initial attempt + 2 retries
 			},
 			expectCalls:    3,
@@ -361,7 +362,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 			},
 			setupMocks: func() {
 				s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
-					Return(fmt.Errorf("deadline exceeded")).
+					Return(errors.New("deadline exceeded")).
 					Maybe() // May be called multiple times before context cancellation
 			},
 			expectCalls:    1, // At least one call before cancellation
@@ -381,7 +382,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 			setupMocks: func() {
 				// First call fails with custom retryable error
 				s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
-					Return(fmt.Errorf("custom error pattern occurred")).
+					Return(errors.New("custom error pattern occurred")).
 					Once()
 
 				// Second call succeeds

--- a/contrib/vfsevents/watchers/gcsevents/gcsevents_test.go
+++ b/contrib/vfsevents/watchers/gcsevents/gcsevents_test.go
@@ -450,7 +450,7 @@ func (s *GCSWatcherTestSuite) TestReceiveWithRetry() {
 				func(err error) {
 					// Error handler - should be called on error
 					if !tt.wantErr {
-						s.Fail("Unexpected error: %v", err)
+						s.Require().NoError(err)
 					}
 				},
 				status,
@@ -534,7 +534,7 @@ func (s *GCSWatcherTestSuite) TestRetryBackoffTiming() {
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify event was processed
-	s.GreaterOrEqual(len(receivedEvents), 0, "Should process events without error")
+	s.NotEmpty(receivedEvents, "Should process events without error")
 }
 
 func (s *GCSWatcherTestSuite) TestMapGCSEventType() {
@@ -683,7 +683,7 @@ func (s *GCSWatcherTestSuite) TestEnhancedMetadata() {
 		receivedEvent = &event
 	}
 	errHandler := func(err error) {
-		s.Fail("Unexpected error: %v", err)
+		s.Require().NoError(err)
 	}
 
 	s.pubsubClient.On("Receive", mock.Anything, mock.Anything).
@@ -732,7 +732,7 @@ func (s *GCSWatcherTestSuite) TestOverwriteEventSuppression() {
 		receivedEvents = append(receivedEvents, event)
 	}
 	errHandler := func(err error) {
-		s.Fail("Unexpected error: %v", err)
+		s.Require().NoError(err)
 	}
 
 	// Simulate GCS overwrite scenario: two events for one logical operation

--- a/contrib/vfsevents/watchers/s3events/s3events.go
+++ b/contrib/vfsevents/watchers/s3events/s3events.go
@@ -4,6 +4,7 @@ package s3events
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -101,7 +102,7 @@ func WithReceivedCount(count uint) Option {
 func NewS3Watcher(queueURL string, opts ...Option) (*S3Watcher, error) {
 	// validate queueURL
 	if queueURL == "" {
-		return nil, fmt.Errorf("queueURL cannot be empty")
+		return nil, errors.New("queueURL cannot be empty")
 	}
 
 	w := &S3Watcher{
@@ -137,7 +138,7 @@ func (w *S3Watcher) Start(
 	defer w.mu.Unlock()
 
 	if w.cancel != nil {
-		return fmt.Errorf("S3 watcher is already running")
+		return errors.New("S3 watcher is already running")
 	}
 
 	// Process start options
@@ -306,7 +307,7 @@ func (w *S3Watcher) processMessage(
 				metadata["sequencer"] = s3Event.Records[i].S3.Object.Sequencer
 			}
 			if s3Event.Records[i].S3.Object.Size > 0 {
-				metadata["size"] = fmt.Sprintf("%d", s3Event.Records[i].S3.Object.Size)
+				metadata["size"] = strconv.FormatInt(s3Event.Records[i].S3.Object.Size, 10)
 			}
 
 			event := vfsevents.Event{

--- a/contrib/vfsevents/watchers/s3events/s3events.go
+++ b/contrib/vfsevents/watchers/s3events/s3events.go
@@ -21,7 +21,7 @@ import (
 
 // S3Event represents the structure of an S3 event.
 type S3Event struct {
-	Records []S3Record `json:"Records"`
+	Records []S3Record `json:"records"`
 }
 
 // S3Record represents a single record in an S3 event.
@@ -41,7 +41,7 @@ type S3UserIdentity struct {
 
 // S3RequestParams represents the request parameters in an S3 event.
 type S3RequestParams struct {
-	SourceIPAddress string `json:"sourceIPAddress"`
+	SourceIPAddress string `json:"sourceIpAddress"`
 }
 
 // S3Entity represents the S3 entity in an S3 event.

--- a/contrib/vfsevents/watchers/s3events/s3events_test.go
+++ b/contrib/vfsevents/watchers/s3events/s3events_test.go
@@ -3,6 +3,7 @@ package s3events
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -281,7 +282,7 @@ func (s *S3WatcherTestSuite) TestPoll() {
 					MaxNumberOfMessages:         10,
 					WaitTimeSeconds:             20,
 					MessageSystemAttributeNames: []types.MessageSystemAttributeName{"ApproximateReceiveCount"},
-				}).Return(nil, fmt.Errorf("receive message error")).Once()
+				}).Return(nil, errors.New("receive message error")).Once()
 			},
 			wantErr: true,
 		},
@@ -381,7 +382,7 @@ func (s *S3WatcherTestSuite) TestPollWithRetry() {
 					MaxNumberOfMessages:         10,
 					WaitTimeSeconds:             20,
 					MessageSystemAttributeNames: []types.MessageSystemAttributeName{"ApproximateReceiveCount"},
-				}).Return(nil, fmt.Errorf("network error")).Maybe()
+				}).Return(nil, errors.New("network error")).Maybe()
 			},
 			wantErr:        false, // poll method returns nil on context cancellation
 			contextTimeout: 50 * time.Millisecond,

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller.go
@@ -3,6 +3,7 @@ package vfspoller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -78,7 +79,7 @@ func WithCleanupAge(age time.Duration) Option {
 func NewPoller(location vfs.Location, opts ...Option) (*Poller, error) {
 	// validate location
 	if location == nil {
-		return nil, fmt.Errorf("location cannot be nil")
+		return nil, errors.New("location cannot be nil")
 	}
 	exists, err := location.Exists()
 	if err != nil {
@@ -116,7 +117,7 @@ func (p *Poller) Start(
 	defer p.mu.Unlock()
 
 	if p.cancel != nil {
-		return fmt.Errorf("poller is already running")
+		return errors.New("poller is already running")
 	}
 
 	// Process start options

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller.go
@@ -195,7 +195,7 @@ func (p *Poller) poll(handler vfsevents.HandlerFunc, config *vfsevents.StartConf
 	// Retry List() operation if retry is enabled
 	if config.RetryConfig.Enabled {
 		var lastErr error
-		for attempt := 0; attempt <= config.RetryConfig.MaxRetries; attempt++ {
+		for attempt := range config.RetryConfig.MaxRetries + 1 {
 			filenames, err = p.location.List()
 			if err == nil {
 				// Success - reset consecutive error count
@@ -454,7 +454,7 @@ func (p *Poller) enforceMaxFiles() {
 
 	// Remove the oldest files to get back to maxFiles
 	numToRemove := len(entries) - p.maxFiles
-	for i := 0; i < numToRemove; i++ {
+	for i := range numToRemove {
 		delete(p.fileCache, entries[i].uri)
 	}
 }

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller.go
@@ -441,7 +441,7 @@ func (p *Poller) enforceMaxFiles() {
 		firstSeen time.Time
 	}
 
-	var entries []fileEntry
+	entries := make([]fileEntry, 0, len(p.fileCache))
 	for uri, fileInfo := range p.fileCache {
 		entries = append(entries, fileEntry{uri: uri, firstSeen: fileInfo.FirstSeen})
 	}

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
@@ -2,6 +2,7 @@ package vfspoller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -180,7 +181,7 @@ func (s *PollerTestSuite) TestPoll() {
 		{
 			name: "List error",
 			setupMocks: func(loc *mocks.Location) {
-				loc.EXPECT().List().Return(nil, fmt.Errorf("list error"))
+				loc.EXPECT().List().Return(nil, errors.New("list error"))
 			},
 			wantErr: true,
 		},
@@ -188,7 +189,7 @@ func (s *PollerTestSuite) TestPoll() {
 			name: "NewFile error",
 			setupMocks: func(loc *mocks.Location) {
 				loc.EXPECT().List().Return([]string{"file1"}, nil)
-				loc.EXPECT().NewFile("file1").Return(nil, fmt.Errorf("new file error"))
+				loc.EXPECT().NewFile("file1").Return(nil, errors.New("new file error"))
 			},
 			wantErr: true,
 		},
@@ -288,7 +289,7 @@ func (s *PollerTestSuite) TestPollWithRetry() {
 		{
 			name: "Retry disabled - fail immediately",
 			setupMocks: func(loc *mocks.Location) {
-				loc.EXPECT().List().Return(nil, fmt.Errorf("connection timeout")).Once()
+				loc.EXPECT().List().Return(nil, errors.New("connection timeout")).Once()
 			},
 			retryConfig: vfsevents.RetryConfig{
 				Enabled: false,
@@ -302,7 +303,7 @@ func (s *PollerTestSuite) TestPollWithRetry() {
 			name: "Retryable error with success on second attempt",
 			setupMocks: func(loc *mocks.Location) {
 				// First call fails with retryable error
-				loc.EXPECT().List().Return(nil, fmt.Errorf("connection timeout")).Once()
+				loc.EXPECT().List().Return(nil, errors.New("connection timeout")).Once()
 				// Second call succeeds
 				loc.EXPECT().List().Return([]string{"file1"}, nil).Once()
 				file := mocks.NewFile(s.T())
@@ -327,7 +328,7 @@ func (s *PollerTestSuite) TestPollWithRetry() {
 		{
 			name: "Non-retryable error - fail immediately",
 			setupMocks: func(loc *mocks.Location) {
-				loc.EXPECT().List().Return(nil, fmt.Errorf("permission denied")).Once()
+				loc.EXPECT().List().Return(nil, errors.New("permission denied")).Once()
 			},
 			retryConfig: vfsevents.RetryConfig{
 				Enabled:         true,
@@ -346,7 +347,7 @@ func (s *PollerTestSuite) TestPollWithRetry() {
 			name: "Max retries exceeded",
 			setupMocks: func(loc *mocks.Location) {
 				// All attempts fail with retryable error
-				loc.EXPECT().List().Return(nil, fmt.Errorf("connection timeout")).Times(3) // MaxRetries=2 means 3 total attempts
+				loc.EXPECT().List().Return(nil, errors.New("connection timeout")).Times(3) // MaxRetries=2 means 3 total attempts
 			},
 			retryConfig: vfsevents.RetryConfig{
 				Enabled:         true,
@@ -365,7 +366,7 @@ func (s *PollerTestSuite) TestPollWithRetry() {
 			name: "Custom retryable error patterns",
 			setupMocks: func(loc *mocks.Location) {
 				// First call fails with custom retryable error
-				loc.EXPECT().List().Return(nil, fmt.Errorf("S3 SlowDown")).Once()
+				loc.EXPECT().List().Return(nil, errors.New("S3 SlowDown")).Once()
 				// Second call succeeds
 				loc.EXPECT().List().Return([]string{}, nil).Once()
 			},

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
@@ -588,7 +588,7 @@ func (s *PollerTestSuite) TestEnforceMaxFiles() {
 			poller.enforceMaxFiles()
 
 			// Verify cache size
-			s.Equal(tt.expectedSize, len(poller.fileCache), "Cache size should match expected")
+			s.Len(poller.fileCache, tt.expectedSize, "Cache size should match expected")
 
 			// If enforcement was needed, verify oldest files were removed
 			if len(tt.initialCache) > tt.maxFiles && tt.maxFiles > 0 {

--- a/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
+++ b/contrib/vfsevents/watchers/vfspoller/vfspoller_test.go
@@ -597,7 +597,7 @@ func (s *PollerTestSuite) TestEnforceMaxFiles() {
 					uri       string
 					firstSeen time.Time
 				}
-				var entries []fileEntry
+				entries := make([]fileEntry, 0, len(tt.initialCache))
 				for uri, info := range tt.initialCache {
 					entries = append(entries, fileEntry{uri: uri, firstSeen: info.FirstSeen})
 				}

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -428,7 +428,7 @@ type Options struct {
 	APIKey         string   `json:"apiKey,omitempty"`
 	CredentialFile string   `json:"credentialFilePath,omitempty"`
 	Endpoint       string   `json:"endpoint,omitempty"`
-	Scopes         []string `json:"WithoutAuthentication,omitempty"`
+	Scopes         []string `json:"withoutAuthentication,omitempty"`
 }
 ```
 

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -463,7 +463,7 @@ type Options struct {
 	SecretAccessKey             string `json:"secretAccessKey,omitempty"`
 	SessionToken                string `json:"sessionToken,omitempty"`
 	Region                      string `json:"region,omitempty"`
-	RoleARN                     string `json:"roleARN,omitempty"`
+	RoleARN                     string `json:"roleArn,omitempty"`
 	Endpoint                    string `json:"endpoint,omitempty"`
 	ACL                         string `json:"acl,omitempty"`
 	ForcePathStyle              bool   `json:"forcePathStyle,omitempty"`

--- a/errors.go
+++ b/errors.go
@@ -7,8 +7,12 @@ type Error string
 func (e Error) Error() string { return string(e) }
 
 const (
+	// ErrCopyToNotPossible - CopyTo/MoveTo operations are only possible when seek position is 0,0
+	ErrCopyToNotPossible = Error("current cursor offset is not 0 as required for this operation")
+
 	// CopyToNotPossible - CopyTo/MoveTo operations are only possible when seek position is 0,0
-	CopyToNotPossible = Error("current cursor offset is not 0 as required for this operation")
+	// Deprecated: Use ErrCopyToNotPossible instead
+	CopyToNotPossible = ErrCopyToNotPossible //nolint:errname
 
 	// ErrNotExist - File does not exist
 	ErrNotExist = Error("file does not exist")

--- a/utils/errors_test.go
+++ b/utils/errors_test.go
@@ -1,7 +1,7 @@
 package utils_test
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -19,7 +19,7 @@ type errorsSuite struct {
 
 // TestErrorWrapFunctions tests all error wrap functions with both nil and non-nil errors
 func (s *errorsSuite) TestErrorWrapFunctions() {
-	testError := fmt.Errorf("test error")
+	testError := errors.New("test error")
 
 	testCases := []struct {
 		name        string
@@ -109,7 +109,7 @@ func (s *errorsSuite) TestErrorWrapFunctions() {
 
 // TestErrorWrapFunctionsWithUnwrap tests that wrapped errors can be unwrapped
 func (s *errorsSuite) TestErrorWrapFunctionsWithUnwrap() {
-	originalError := fmt.Errorf("original error")
+	originalError := errors.New("original error")
 
 	testCases := []struct {
 		name     string

--- a/vfs.go
+++ b/vfs.go
@@ -257,7 +257,7 @@ type Options interface{}
 //
 //	var retrier Retry = func(wrapped func() error) error {
 //	  var ret error
-//	  for i := 0; i < 5; i++ {
+//	  for range 5 {
 //	     if err := wrapped(); err != nil { ret = err; continue }
 //	  }
 //	  return ret

--- a/vfs.go
+++ b/vfs.go
@@ -177,7 +177,7 @@ type File interface {
 	//   * In the case of an error, nil is returned for the file.
 	//   * CopyToLocation should use native functions when possible within the same scheme.
 	//   * If the file already exists at the location, the contents will be overwritten with the current file's contents.
-	//   * Unless Seek position is at 0,0 a vfs.CopyToNotPossible will be returned
+	//   * Unless Seek position is at 0,0 a vfs.ErrCopyToNotPossible will be returned
 	//   * CopyToLocation will Close both the source and target Files which therefore can't be appended to without first
 	//     calling Seek() to move the cursor to the end of the file.
 	CopyToLocation(location Location) (File, error)
@@ -187,7 +187,7 @@ type File interface {
 	//   * In the case of an error, nil is returned for the file.
 	//   * CopyToLocation should use native functions when possible within the same scheme.
 	//   * If the file already exists, the contents will be overwritten with the current file's contents.
-	//   * Unless Seek position is at 0,0 a vfs.CopyToNotPossible will be returned
+	//   * Unless Seek position is at 0,0 a vfs.ErrCopyToNotPossible will be returned
 	//   * CopyToFile will Close both the source and target Files which therefore can't be appended to without first
 	//     calling Seek() to move the cursor to the end of the file.
 	CopyToFile(file File) error
@@ -200,7 +200,7 @@ type File interface {
 	//   * In the case of an error, nil is returned for the file.
 	//   * When moving within the same Scheme, native move/rename should be used where possible.
 	//   * If the file already exists, the contents will be overwritten with the current file's contents.
-	//   * Unless Seek position is at 0,0 a vfs.CopyToNotPossible will be returned
+	//   * Unless Seek position is at 0,0 a vfs.ErrCopyToNotPossible will be returned
 	//   * MoveToLocation will Close both the source and target Files which therefore can't be appended to without first
 	//     calling Seek() to move the cursor to the end of the file.
 	MoveToLocation(location Location) (File, error)
@@ -208,7 +208,7 @@ type File interface {
 	// MoveToFile will move the current file to the provided file instance.
 	//
 	//   * If the file already exists, the contents will be overwritten with the current file's contents.
-	//   * Unless Seek position is at 0,0 a vfs.CopyToNotPossible will be returned
+	//   * Unless Seek position is at 0,0 a vfs.ErrCopyToNotPossible will be returned
 	//   * The current instance of the file will be removed.
 	//   * MoveToFile will Close both the source and target Files which therefore can't be appended to without first
 	//     calling Seek() to move the cursor to the end of the file.


### PR DESCRIPTION
This PR enables 9 more golangci-lint linters that I personally use, along with compliance fixes.
I've kept each in a separate commit so they can be selectively removed with ease if desired. I'm fine with squashing the PR on merge, or splitting one or more into separate PRs too.
The only potentially disruptive one is `tagliatelle` since it renames JSON fields.