### PR TITLE
Define more sentinel errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Define more sentinel errors for more ergonomic error checking.
 
 ## [v7.10.0] - 2025-10-07
 ### Security

--- a/backend/azure/fileSystem.go
+++ b/backend/azure/fileSystem.go
@@ -17,7 +17,10 @@ const Scheme = "az"
 // Name defines the name for the azure implementation
 const Name = "azure"
 
-const errNilFileSystemReceiver = "azure.FileSystem receiver pointer must be non-nil"
+var (
+	errFileSystemRequired       = errors.New("azure.FileSystem receiver pointer must be non-nil")
+	errContainerAndPathRequired = errors.New("non-empty strings for container and path are required")
+)
 
 // FileSystem implements the vfs.FileSystem interface for Azure Blob Storage
 type FileSystem struct {
@@ -82,11 +85,11 @@ func (fs *FileSystem) Client() (Client, error) {
 // NewFile returns the azure implementation of vfs.File
 func (fs *FileSystem) NewFile(container, absFilePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if fs == nil {
-		return nil, errors.New(errNilFileSystemReceiver)
+		return nil, errFileSystemRequired
 	}
 
 	if container == "" || absFilePath == "" {
-		return nil, errors.New("non-empty strings for container and path are required")
+		return nil, errContainerAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteFilePath(absFilePath); err != nil {
@@ -106,11 +109,11 @@ func (fs *FileSystem) NewFile(container, absFilePath string, opts ...options.New
 // NewLocation returns the azure implementation of vfs.Location
 func (fs *FileSystem) NewLocation(container, absLocPath string) (vfs.Location, error) {
 	if fs == nil {
-		return nil, errors.New(errNilFileSystemReceiver)
+		return nil, errFileSystemRequired
 	}
 
 	if container == "" || absLocPath == "" {
-		return nil, errors.New("non-empty strings for container and path are required")
+		return nil, errContainerAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteLocationPath(absLocPath); err != nil {

--- a/backend/azure/fileSystem_test.go
+++ b/backend/azure/fileSystem_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/c2fo/vfs/v7/utils"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/c2fo/vfs/v7"
@@ -22,23 +23,22 @@ func (s *FileSystemTestSuite) TestVFSFileSystemImplementor() {
 func (s *FileSystemTestSuite) TestNewFile() {
 	fs := NewFileSystem()
 	file, err := fs.NewFile("", "")
-	s.Require().EqualError(err, "non-empty strings for container and path are required", "volume and path are required")
+	s.Require().ErrorIs(err, errContainerAndPathRequired)
 	s.Nil(file)
 
 	fs = NewFileSystem()
 	file, err = fs.NewFile("temp", "")
-	s.Require().EqualError(err, "non-empty strings for container and path are required", "volume and path are required")
+	s.Require().ErrorIs(err, errContainerAndPathRequired)
 	s.Nil(file)
 
 	fs = NewFileSystem()
 	file, err = fs.NewFile("", "/blah/blah.txt")
-	s.Require().EqualError(err, "non-empty strings for container and path are required", "volume and path are required")
+	s.Require().ErrorIs(err, errContainerAndPathRequired)
 	s.Nil(file)
 
 	fs = NewFileSystem()
 	file, err = fs.NewFile("temp", "blah/blah.txt")
-	s.Require().EqualError(err, "absolute file path is invalid - must include leading slash and may not include trailing slash",
-		"the path is invalid so we expect an error")
+	s.Require().ErrorIs(err, utils.ErrBadAbsFilePath, "the path is invalid so we expect an error")
 	s.Nil(file, "Since an error was returned we expect a nil file to be returned")
 
 	fs = NewFileSystem()
@@ -51,8 +51,7 @@ func (s *FileSystemTestSuite) TestNewFile() {
 func (s *FileSystemTestSuite) TestNewFile_NilReceiver() {
 	var fs *FileSystem
 	file, err := fs.NewFile("temp", "/foo/bar/test.txt")
-	s.Require().EqualError(err, "azure.FileSystem receiver pointer must be non-nil",
-		"the receiver pointer is nil so we would receive an error")
+	s.Require().ErrorIs(err, errFileSystemRequired, "the receiver pointer is nil so we would receive an error")
 	s.Nil(file, "Since there was an error we expect a nil file to be returned")
 }
 
@@ -74,13 +73,13 @@ func (s *FileSystemTestSuite) TestNewLocation() {
 
 	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "foo/bar/")
-	s.Require().EqualError(err, "absolute location path is invalid - must include leading and trailing slashes",
+	s.Require().ErrorIs(err, utils.ErrBadAbsLocationPath,
 		"The path does not start with a slash and therefore not an absolute path so we expect an error")
 	s.Nil(loc, "Since an error was returned the location is nil")
 
 	fs = NewFileSystem()
 	loc, err = fs.NewLocation("temp", "/foo/bar")
-	s.Require().EqualError(err, "absolute location path is invalid - must include leading and trailing slashes",
+	s.Require().ErrorIs(err, utils.ErrBadAbsLocationPath,
 		"The path does not end with a slash and therefore not an absolute path so we expect an error")
 	s.Nil(loc, "Since an error was returned the location is nil")
 
@@ -106,8 +105,7 @@ func (s *FileSystemTestSuite) TestNewLocation() {
 func (s *FileSystemTestSuite) TestNewLocation_NilReceiver() {
 	var fs *FileSystem
 	loc, err := fs.NewLocation("temp", "/foo/bar/")
-	s.Require().EqualError(err, "azure.FileSystem receiver pointer must be non-nil",
-		"The receiver pointer on the function call is nil so we should get an error")
+	s.Require().ErrorIs(err, errFileSystemRequired, "The receiver pointer on the function call is nil so we should get an error")
 	s.Nil(loc, "The call returned an error so the location should be nil")
 }
 

--- a/backend/azure/location.go
+++ b/backend/azure/location.go
@@ -12,7 +12,7 @@ import (
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
-const errNilLocationReceiver = "azure.Location receiver pointer must be non-nil"
+var errLocationRequired = errors.New("azure.Location receiver pointer must be non-nil")
 
 // Location is the azure implementation of vfs.Location
 type Location struct {
@@ -140,7 +140,7 @@ func (l *Location) Exists() (bool, error) {
 // NewLocation creates a new location instance relative to the current location's path.
 func (l *Location) NewLocation(relLocPath string) (vfs.Location, error) {
 	if l == nil {
-		return nil, errors.New(errNilLocationReceiver)
+		return nil, errLocationRequired
 	}
 
 	if err := utils.ValidateRelativeLocationPath(relLocPath); err != nil {
@@ -161,7 +161,7 @@ func (l *Location) NewLocation(relLocPath string) (vfs.Location, error) {
 //	loc, err := loc.NewLocation("../../")
 func (l *Location) ChangeDir(relLocPath string) error {
 	if l == nil {
-		return errors.New(errNilLocationReceiver)
+		return errLocationRequired
 	}
 
 	err := utils.ValidateRelativeLocationPath(relLocPath)
@@ -186,7 +186,7 @@ func (l *Location) FileSystem() vfs.FileSystem {
 // NewFile returns a new file instance at the given path, relative to the current location.
 func (l *Location) NewFile(relFilePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if l == nil {
-		return nil, errors.New(errNilLocationReceiver)
+		return nil, errLocationRequired
 	}
 
 	if err := utils.ValidateRelativeFilePath(relFilePath); err != nil {

--- a/backend/azure/location_test.go
+++ b/backend/azure/location_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/c2fo/vfs/v7/utils"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -154,8 +155,7 @@ func (s *LocationTestSuite) TestNewLocation() {
 func (s *LocationTestSuite) TestNewLocation_NilReceiver() {
 	var l *Location
 	nl, err := l.NewLocation("test-container/")
-	s.Require().EqualError(err, "azure.Location receiver pointer must be non-nil",
-		"The receiver for NewLocation must be non-nil so we expect an error")
+	s.Require().ErrorIs(err, errLocationRequired, "The receiver for NewLocation must be non-nil so we expect an error")
 	s.Nil(nl, "An error was returned so we expect a nil location to be returned")
 }
 
@@ -176,21 +176,21 @@ func (s *LocationTestSuite) TestChangeDir() {
 	s.Require().NoError(err)
 	l = l.(*Location)
 	err = l.ChangeDir("/test-dir/")
-	s.Require().EqualError(err, "relative location path is invalid - may not include leading slash but must include trailing slash",
+	s.Require().ErrorIs(err, utils.ErrBadRelLocationPath,
 		"The path begins with a slash and therefore is not a relative path so this should return an error")
 
 	l, err = NewFileSystem().NewLocation("test-container", "/")
 	s.Require().NoError(err)
 	l = l.(*Location)
 	err = l.ChangeDir("test-dir")
-	s.Require().EqualError(err, "relative location path is invalid - may not include leading slash but must include trailing slash",
+	s.Require().ErrorIs(err, utils.ErrBadRelLocationPath,
 		"The path does not end with a slash and therefore is not a relative path so this should return an error")
 
 	l, err = NewFileSystem().NewLocation("test-container", "/")
 	s.Require().NoError(err)
 	l = l.(*Location)
 	err = l.ChangeDir("")
-	s.Require().EqualError(err, "relative location path is invalid - may not include leading slash but must include trailing slash",
+	s.Require().ErrorIs(err, utils.ErrBadRelLocationPath,
 		"An empty relative path does not end with a slash and therefore is not a valid relative path so this should return an error")
 }
 
@@ -198,7 +198,7 @@ func (s *LocationTestSuite) TestChangeDir_NilReceiver() {
 	var l *Location
 	s.Nil(l)
 	err := l.ChangeDir("")
-	s.Require().EqualError(err, "azure.Location receiver pointer must be non-nil")
+	s.Require().ErrorIs(err, errLocationRequired)
 }
 
 func (s *LocationTestSuite) TestFileSystem() {
@@ -212,17 +212,17 @@ func (s *LocationTestSuite) TestNewFile() {
 	l, _ := fs.NewLocation("test-container", "/folder/")
 
 	f, err := l.NewFile("")
-	s.Require().EqualError(err, "relative file path is invalid - may not include leading or trailing slashes",
+	s.Require().ErrorIs(err, utils.ErrBadRelFilePath,
 		"Empty string is not a valid relative file path so we expect an error")
 	s.Nil(f, "Since the call to NewFile resulted in an error we expect a nil pointer")
 
 	f, err = l.NewFile("/foo/bar.txt")
-	s.Require().EqualError(err, "relative file path is invalid - may not include leading or trailing slashes",
+	s.Require().ErrorIs(err, utils.ErrBadRelFilePath,
 		"The file path begins with a slash therefore it is not a valid relative file path so we expect an error")
 	s.Nil(f, "Since the call to NewFile resulted in an error we expect a nil pointer")
 
 	f, err = l.NewFile("foo/bar/")
-	s.Require().EqualError(err, "relative file path is invalid - may not include leading or trailing slashes",
+	s.Require().ErrorIs(err, utils.ErrBadRelFilePath,
 		"The file path ends with a slash therefore it is not a valid relative file path so we expect an error")
 	s.Nil(f, "Since the call to NewFile resulted in an error we expect a nil pointer")
 
@@ -251,8 +251,7 @@ func (s *LocationTestSuite) TestNewFile() {
 func (s *LocationTestSuite) TestNewFile_NilReceiver() {
 	var l *Location
 	f, err := l.NewFile("foo/bar.txt")
-	s.Require().EqualError(err, "azure.Location receiver pointer must be non-nil",
-		"Can't create a new file from a nil location so we expect an error")
+	s.Require().ErrorIs(err, errLocationRequired, "Can't create a new file from a nil location so we expect an error")
 	s.Nil(f, "the call to NewFile returned an error so we expect a nil pointer")
 }
 

--- a/backend/ftp/fileSystem.go
+++ b/backend/ftp/fileSystem.go
@@ -20,6 +20,11 @@ const name = "File Transfer Protocol"
 var dataConnGetterFunc func(context.Context, authority.Authority, *FileSystem, *File, types.OpenType) (types.DataConn, error)
 var defaultClientGetter func(context.Context, authority.Authority, Options) (client types.Client, err error)
 
+var (
+	errFileSystemRequired       = errors.New("non-nil gs.FileSystem pointer is required")
+	errAuthorityAndPathRequired = errors.New("non-empty strings for authority and path are required")
+)
+
 // FileSystem implements vfs.FileSystem for the FTP filesystem.
 type FileSystem struct {
 	options   Options
@@ -51,11 +56,11 @@ func (fs *FileSystem) Retry() vfs.Retry {
 // NewFile function returns the FTP implementation of vfs.File.
 func (fs *FileSystem) NewFile(authorityStr, filePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil ftp.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || filePath == "" {
-		return nil, errors.New("non-empty string for authority and path is required")
+		return nil, errAuthorityAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteFilePath(filePath); err != nil {
@@ -75,11 +80,11 @@ func (fs *FileSystem) NewFile(authorityStr, filePath string, opts ...options.New
 // NewLocation function returns the FTP implementation of vfs.Location.
 func (fs *FileSystem) NewLocation(authorityStr, locPath string) (vfs.Location, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil ftp.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || locPath == "" {
-		return nil, errors.New("non-empty string for authority and path is required")
+		return nil, errAuthorityAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteLocationPath(locPath); err != nil {

--- a/backend/ftp/fileSystem_test.go
+++ b/backend/ftp/fileSystem_test.go
@@ -56,11 +56,11 @@ func (ts *fileSystemTestSuite) TestNewFile_Error() {
 	// test nil pointer
 	var nilftpfs *FileSystem
 	_, err := nilftpfs.NewFile("host.com", "/path/to/file.txt")
-	ts.Require().EqualError(err, "non-nil ftp.FileSystem pointer is required", "errors returned by NewFile")
+	ts.Require().ErrorIs(err, errFileSystemRequired, "errors returned by NewFile")
 
 	// test validation error
 	file, err := ts.ftpfs.NewFile("host.com", "relative/path/to/file.txt")
-	ts.Require().EqualError(err, utils.ErrBadAbsFilePath, "errors returned by NewFile")
+	ts.Require().ErrorIs(err, utils.ErrBadAbsFilePath, "errors returned by NewFile")
 	ts.Nil(file, "NewFile shouldn't return a file")
 
 	filePath := ""
@@ -70,7 +70,7 @@ func (ts *fileSystemTestSuite) TestNewFile_Error() {
 
 	filePath = "/some/file.txt"
 	file, err = ts.ftpfs.NewFile("", filePath)
-	ts.Require().EqualError(err, "non-empty string for authority and path is required", "bad authority")
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired, "bad authority")
 	ts.Nil(file, "NewFile(%s) shouldn't return a file", filePath)
 }
 
@@ -85,21 +85,21 @@ func (ts *fileSystemTestSuite) TestNewLocation_Error() {
 	// test nil pointer
 	var nilftpfs *FileSystem
 	_, err := nilftpfs.NewLocation("somehost.com", "/path/to/")
-	ts.Require().EqualError(err, "non-nil ftp.FileSystem pointer is required", "errors returned by NewLocation")
+	ts.Require().ErrorIs(err, errFileSystemRequired, "errors returned by NewLocation")
 
 	// test validation error
 	file, err := ts.ftpfs.NewLocation("host.com", "relative/path/to/")
-	ts.Require().EqualError(err, utils.ErrBadAbsLocationPath, "errors returned by NewLocation")
+	ts.Require().ErrorIs(err, utils.ErrBadAbsLocationPath, "errors returned by NewLocation")
 	ts.Nil(file, "NewFile shouldn't return a file")
 
 	locPath := ""
 	file, err = ts.ftpfs.NewLocation("host.com", locPath)
-	ts.Require().EqualError(err, "non-empty string for authority and path is required", "NewLocation(%s)", locPath)
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired, "NewLocation(%s)", locPath)
 	ts.Nil(file, "NewLocation(%s) shouldn't return a file", locPath)
 
 	locPath = "/path/"
 	file, err = ts.ftpfs.NewLocation("", locPath)
-	ts.Require().EqualError(err, "non-empty string for authority and path is required", "NewLocation(%s)", locPath)
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired, "NewLocation(%s)", locPath)
 	ts.Nil(file, "NewLocation(%s) shouldn't return a file", locPath)
 }
 

--- a/backend/ftp/file_test.go
+++ b/backend/ftp/file_test.go
@@ -558,7 +558,7 @@ func (ts *fileTestSuite) TestCopyToLocation() {
 	newFile, err = sourceFile.CopyToLocation(targetLocation)
 	ts.Require().Error(err, "error is expected")
 	ts.Nil(newFile, "newFile is nil")
-	ts.Require().ErrorContains(err, utils.ErrBadRelFilePath, "error is correct type")
+	ts.Require().ErrorIs(err, utils.ErrBadRelFilePath, "error is correct type")
 }
 
 func (ts *fileTestSuite) TestMoveToFile_differentAuthority() {
@@ -745,7 +745,7 @@ func (ts *fileTestSuite) TestMoveToLocation() {
 	sourceFile.path = ""
 	newFile, err = sourceFile.MoveToLocation(targetLocation)
 	ts.Require().Error(err, "error is expected")
-	ts.Require().ErrorContains(err, utils.ErrBadRelFilePath, "error is the right type of error")
+	ts.Require().ErrorIs(err, utils.ErrBadRelFilePath, "error is the right type of error")
 	ts.Nil(newFile, "newFile should be nil on error")
 }
 
@@ -1132,17 +1132,18 @@ func (ts *fileTestSuite) TestStringer() {
 }
 
 func (ts *fileTestSuite) TestNewFile() {
-	ftpFS := &FileSystem{}
+	var ftpFS *FileSystem
 	// ftpFS is nil
 	_, err := ftpFS.NewFile("user@host.com", "")
-	ts.Require().Error(err, "non-nil ftp.FileSystem pointer is required")
+	ts.Require().ErrorIs(err, errFileSystemRequired)
 
+	ftpFS = &FileSystem{}
 	// authority is ""
 	_, err = ftpFS.NewFile("", "asdf")
-	ts.Require().Error(err, "non-empty strings for bucket and key are required")
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired)
 	// path is ""
 	_, err = ftpFS.NewFile("user@host.com", "")
-	ts.Require().Error(err, "non-empty strings for bucket and key are required")
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired)
 
 	authorityStr := "user@host.com"
 	key := "/path/to/file"

--- a/backend/ftp/location.go
+++ b/backend/ftp/location.go
@@ -17,6 +17,8 @@ import (
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
+var errLocationRequired = errors.New("non-nil ftp.Location pointer is required")
+
 // Location implements the vfs.Location interface specific to ftp fs.
 type Location struct {
 	fileSystem *FileSystem
@@ -182,7 +184,7 @@ func (l *Location) Exists() (bool, error) {
 // ChangeDir, which, for the FTP implementation doesn't ever result in an error.
 func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 	if l == nil {
-		return nil, errors.New("non-nil ftp.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if err := utils.ValidateRelativeLocationPath(relativePath); err != nil {
@@ -221,7 +223,7 @@ func (l *Location) ChangeDir(relativePath string) error {
 // argument is expected to be a relative path to the location's current path.
 func (l *Location) NewFile(relFilePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if l == nil {
-		return nil, errors.New("non-nil ftp.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if err := utils.ValidateRelativeFilePath(relFilePath); err != nil {

--- a/backend/ftp/location_test.go
+++ b/backend/ftp/location_test.go
@@ -225,7 +225,7 @@ func (lt *locationTestSuite) TestListByPrefix() {
 	badprefix := ""
 	fileList, err = loc.ListByPrefix(badprefix)
 	lt.Require().Error(err, "error expected")
-	lt.Require().ErrorContains(err, utils.ErrBadPrefix, "err should be correct type")
+	lt.Require().ErrorIs(err, utils.ErrBadPrefix, "err should be correct type")
 	lt.Equal(expectedEmptyStringSlice, fileList, "fileList should be empty string slice")
 
 	// error getting client
@@ -382,11 +382,11 @@ func (lt *locationTestSuite) TestNewFile() {
 
 	// test empty path error
 	_, err = loc.NewFile("")
-	lt.Require().EqualError(err, utils.ErrBadRelFilePath, "errors returned by NewFile")
+	lt.Require().ErrorIs(err, utils.ErrBadRelFilePath, "errors returned by NewFile")
 
 	// test validation error
 	_, err = loc.NewFile("/absolute/path/to/file.txt")
-	lt.Require().EqualError(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
 
 	// new tests for location update
 	lt.Run("new file with relative path updates location", func() {
@@ -525,11 +525,11 @@ func (lt *locationTestSuite) TestNewLocation() {
 
 	// test empty path error
 	_, err = loc.NewLocation("")
-	lt.Require().EqualError(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
 
 	// test validation error
 	_, err = loc.NewLocation("/absolute/path/to/")
-	lt.Require().EqualError(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
 }
 
 func (lt *locationTestSuite) TestDeleteFile() {
@@ -551,7 +551,7 @@ func (lt *locationTestSuite) TestDeleteFile() {
 	// getting NewFile
 	err = loc.DeleteFile("")
 	lt.Require().Error(err, "failed delete")
-	lt.Require().ErrorContains(err, utils.ErrBadRelFilePath, "failed delete")
+	lt.Require().ErrorIs(err, utils.ErrBadRelFilePath, "failed delete")
 }
 
 func TestLocation(t *testing.T) {

--- a/backend/gs/fileSystem.go
+++ b/backend/gs/fileSystem.go
@@ -32,6 +32,11 @@ var noOpRetryer Retryer = func(wrapped func() error) error {
 	return wrapped()
 }
 
+var (
+	errFileSystemRequired       = errors.New("non-nil gs.FileSystem pointer is required")
+	errAuthorityAndPathRequired = errors.New("non-empty strings for authority and path are required")
+)
+
 // NewFileSystem initializer for FileSystem struct accepts google cloud storage client and returns FileSystem or error.
 func NewFileSystem(opts ...options.NewFileSystemOption[FileSystem]) *FileSystem {
 	fs := &FileSystem{
@@ -56,11 +61,11 @@ func (fs *FileSystem) Retry() vfs.Retry {
 // NewFile function returns the gcs implementation of vfs.File.
 func (fs *FileSystem) NewFile(authorityStr, filePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil gs.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || filePath == "" {
-		return nil, errors.New("non-empty strings for Bucket and Key are required")
+		return nil, errAuthorityAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteFilePath(filePath); err != nil {
@@ -81,11 +86,11 @@ func (fs *FileSystem) NewFile(authorityStr, filePath string, opts ...options.New
 // NewLocation function returns the GCS implementation of vfs.Location.
 func (fs *FileSystem) NewLocation(authorityStr, locPath string) (loc vfs.Location, err error) {
 	if fs == nil {
-		return nil, errors.New("non-nil gs.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || locPath == "" {
-		return nil, errors.New("non-empty strings for bucket and key are required")
+		return nil, errAuthorityAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteLocationPath(locPath); err != nil {

--- a/backend/gs/filesystem_test.go
+++ b/backend/gs/filesystem_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/c2fo/vfs/v7/utils"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/option"
 )
@@ -20,42 +21,42 @@ func TestFileSystemSuite(t *testing.T) {
 
 func (s *fileSystemSuite) TestNewFile() {
 	testCases := []struct {
-		description       string
-		volume            string
-		filename          string
-		expectedErrString string
-		nilFS             bool
+		description string
+		volume      string
+		filename    string
+		expectedErr error
+		nilFS       bool
 	}{
 		{
-			description:       "nil filesystem",
-			volume:            "bucket",
-			filename:          "/file.txt",
-			expectedErrString: "non-nil gs.FileSystem pointer is required",
-			nilFS:             true,
+			description: "nil filesystem",
+			volume:      "bucket",
+			filename:    "/file.txt",
+			expectedErr: errFileSystemRequired,
+			nilFS:       true,
 		},
 		{
-			description:       "empty volume",
-			volume:            "",
-			filename:          "/file.txt",
-			expectedErrString: "non-empty strings for Bucket and Key are required",
+			description: "empty volume",
+			volume:      "",
+			filename:    "/file.txt",
+			expectedErr: errAuthorityAndPathRequired,
 		},
 		{
-			description:       "empty filename",
-			volume:            "bucket",
-			filename:          "",
-			expectedErrString: "non-empty strings for Bucket and Key are required",
+			description: "empty filename",
+			volume:      "bucket",
+			filename:    "",
+			expectedErr: errAuthorityAndPathRequired,
 		},
 		{
-			description:       "invalid filename",
-			volume:            "bucket",
-			filename:          "/file.txt/",
-			expectedErrString: "absolute file path is invalid - must include leading slash and may not include trailing slash",
+			description: "invalid filename",
+			volume:      "bucket",
+			filename:    "/file.txt/",
+			expectedErr: utils.ErrBadAbsFilePath,
 		},
 		{
-			description:       "valid filename",
-			volume:            "bucket",
-			filename:          "/file.txt",
-			expectedErrString: "",
+			description: "valid filename",
+			volume:      "bucket",
+			filename:    "/file.txt",
+			expectedErr: nil,
 		},
 	}
 
@@ -66,53 +67,53 @@ func (s *fileSystemSuite) TestNewFile() {
 				fs = nil
 			}
 			_, err := fs.NewFile(tc.volume, tc.filename)
-			if tc.expectedErrString == "" {
+			if tc.expectedErr == nil {
 				s.Require().NoError(err)
 				return
 			}
-			s.Require().EqualError(err, tc.expectedErrString)
+			s.Require().ErrorIs(err, tc.expectedErr)
 		})
 	}
 }
 
 func (s *fileSystemSuite) TestNewLocation() {
 	testCases := []struct {
-		description       string
-		volume            string
-		name              string
-		expectedErrString string
-		nilFS             bool
+		description string
+		volume      string
+		name        string
+		expectedErr error
+		nilFS       bool
 	}{
 		{
-			description:       "nil filesystem",
-			volume:            "bucket",
-			name:              "/",
-			expectedErrString: "non-nil gs.FileSystem pointer is required",
-			nilFS:             true,
+			description: "nil filesystem",
+			volume:      "bucket",
+			name:        "/",
+			expectedErr: errFileSystemRequired,
+			nilFS:       true,
 		},
 		{
-			description:       "empty volume",
-			volume:            "",
-			name:              "/",
-			expectedErrString: "non-empty strings for bucket and key are required",
+			description: "empty volume",
+			volume:      "",
+			name:        "/",
+			expectedErr: errAuthorityAndPathRequired,
 		},
 		{
-			description:       "empty name",
-			volume:            "bucket",
-			name:              "",
-			expectedErrString: "non-empty strings for bucket and key are required",
+			description: "empty name",
+			volume:      "bucket",
+			name:        "",
+			expectedErr: errAuthorityAndPathRequired,
 		},
 		{
-			description:       "invalid name",
-			volume:            "bucket",
-			name:              "/path",
-			expectedErrString: "absolute location path is invalid - must include leading and trailing slashes",
+			description: "invalid name",
+			volume:      "bucket",
+			name:        "/path",
+			expectedErr: utils.ErrBadAbsLocationPath,
 		},
 		{
-			description:       "valid name",
-			volume:            "bucket",
-			name:              "/path/",
-			expectedErrString: "",
+			description: "valid name",
+			volume:      "bucket",
+			name:        "/path/",
+			expectedErr: nil,
 		},
 	}
 
@@ -123,11 +124,11 @@ func (s *fileSystemSuite) TestNewLocation() {
 				fs = nil
 			}
 			_, err := fs.NewLocation(tc.volume, tc.name)
-			if tc.expectedErrString == "" {
+			if tc.expectedErr == nil {
 				s.Require().NoError(err)
 				return
 			}
-			s.Require().EqualError(err, tc.expectedErrString)
+			s.Require().ErrorIs(err, tc.expectedErr)
 		})
 	}
 }

--- a/backend/gs/location.go
+++ b/backend/gs/location.go
@@ -15,6 +15,11 @@ import (
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
+var (
+	errLocationRequired = errors.New("non-nil gs.Location pointer is required")
+	errPathRequired     = errors.New("non-empty string for path is required")
+)
+
 // Location implements vfs.Location for gs fs.
 type Location struct {
 	fileSystem   *FileSystem
@@ -132,11 +137,11 @@ func (l *Location) Exists() (bool, error) {
 // NewLocation creates a new location instance relative to the current location's path.
 func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 	if l == nil {
-		return nil, errors.New("non-nil gs.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if relativePath == "" {
-		return nil, errors.New("non-empty string relativePath is required")
+		return nil, errPathRequired
 	}
 
 	if err := utils.ValidateRelativeLocationPath(relativePath); err != nil {
@@ -157,11 +162,11 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 //	loc, err := loc.NewLocation("../../")
 func (l *Location) ChangeDir(relativePath string) error {
 	if l == nil {
-		return errors.New("non-nil gs.Location pointer is required")
+		return errLocationRequired
 	}
 
 	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
+		return errPathRequired
 	}
 
 	err := utils.ValidateRelativeLocationPath(relativePath)
@@ -186,11 +191,11 @@ func (l *Location) FileSystem() vfs.FileSystem {
 // NewFile returns a new file instance at the given path, relative to the current location.
 func (l *Location) NewFile(relFilePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if l == nil {
-		return nil, errors.New("non-nil gs.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if relFilePath == "" {
-		return nil, errors.New("non-empty string filePath is required")
+		return nil, errPathRequired
 	}
 
 	err := utils.ValidateRelativeFilePath(relFilePath)

--- a/backend/gs/location_test.go
+++ b/backend/gs/location_test.go
@@ -160,15 +160,15 @@ func (lt *locationTestSuite) TestNewFile() {
 	// test nil pointer
 	var nilLoc *Location
 	_, err = nilLoc.NewFile("/path/to/file.txt")
-	lt.Require().EqualError(err, "non-nil gs.Location pointer is required", "errors returned by NewFile")
+	lt.Require().ErrorIs(err, errLocationRequired, "errors returned by NewFile")
 
 	// test empty path error
 	_, err = loc.NewFile("")
-	lt.Require().EqualError(err, "non-empty string filePath is required", "errors returned by NewFile")
+	lt.Require().ErrorIs(err, errPathRequired, "errors returned by NewFile")
 
 	// test validation error
 	_, err = loc.NewFile("/absolute/path/to/file.txt")
-	lt.Require().EqualError(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
 
 	// new tests for location update
 	lt.Run("new file with relative path updates location", func() {
@@ -227,7 +227,7 @@ func (lt *locationTestSuite) TestChangeDir() {
 	// test nil Location
 	var nilLoc *Location
 	err := nilLoc.ChangeDir("path/to/")
-	lt.Require().EqualErrorf(err, "non-nil gs.Location pointer is required", "error expected for nil location")
+	lt.Require().ErrorIsf(err, errLocationRequired, "error expected for nil location")
 
 	auth, err := authority.NewAuthority("bucket")
 	lt.Require().NoError(err)
@@ -273,15 +273,15 @@ func (lt *locationTestSuite) TestNewLocation() {
 	// test nil pointer
 	var nilLoc *Location
 	_, err = nilLoc.NewLocation("/path/to/")
-	lt.Require().EqualError(err, "non-nil gs.Location pointer is required", "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, errLocationRequired, "errors returned by NewLocation")
 
 	// test empty path error
 	_, err = loc.NewLocation("")
-	lt.Require().EqualError(err, "non-empty string relativePath is required", "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, errPathRequired, "errors returned by NewLocation")
 
 	// test validation error
 	_, err = loc.NewLocation("/absolute/path/to/")
-	lt.Require().EqualError(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
 }
 
 func (lt *locationTestSuite) TestStringURI() {

--- a/backend/mem/file.go
+++ b/backend/mem/file.go
@@ -48,9 +48,7 @@ type File struct {
 	seekCalled      bool
 }
 
-func nilReference() error {
-	return errors.New("the target file passed in was nil")
-}
+var errNilReference = errors.New("the target file passed in was nil")
 
 // Close imitates io.Closer by resetting the cursor and setting a boolean
 func (f *File) Close() error {
@@ -300,7 +298,7 @@ func (f *File) CopyToLocation(location vfs.Location) (vfs.File, error) {
 // after this is called, f's cursor will reset as if it had been closed.
 func (f *File) CopyToFile(target vfs.File) (err error) {
 	if f == nil || target == nil {
-		return nilReference()
+		return errNilReference
 	}
 	// Close file (f) reader regardless of an error
 	defer func() {
@@ -348,7 +346,7 @@ func (f *File) CopyToFile(target vfs.File) (err error) {
 // creating a copy of 'f' in "location".  'f' is subsequently  deleted
 func (f *File) MoveToLocation(location vfs.Location) (vfs.File, error) {
 	if f == nil || location == nil {
-		return nil, nilReference()
+		return nil, errNilReference
 	}
 
 	if exists, err := f.Exists(); !exists {
@@ -407,7 +405,7 @@ func (f *File) MoveToLocation(location vfs.Location) (vfs.File, error) {
 // The receiver is always deleted (since it's being "moved")
 func (f *File) MoveToFile(file vfs.File) error {
 	if f == nil {
-		return nilReference()
+		return errNilReference
 	}
 
 	if exists, err := f.Exists(); !exists {

--- a/backend/os/fileSystem_test.go
+++ b/backend/os/fileSystem_test.go
@@ -37,7 +37,7 @@ func (o *osFileSystemTest) TestNewFile() {
 
 	// failure on validation
 	file, err := fs.NewFile("", "invalid/file")
-	o.Require().EqualError(err, utils.ErrBadAbsFilePath, "error expected for invalid file")
+	o.Require().ErrorIs(err, utils.ErrBadAbsFilePath, "error expected for invalid file")
 	o.Nil(file, "file should be nil on err")
 
 	// success
@@ -51,11 +51,11 @@ func (o *osFileSystemTest) TestNewLocation() {
 
 	// failure on validation
 	loc, err := fs.NewLocation("", "/invalid/location")
-	o.Require().EqualError(err, utils.ErrBadAbsLocationPath, "error expected for invalid file")
+	o.Require().ErrorIs(err, utils.ErrBadAbsLocationPath, "error expected for invalid file")
 	o.Nil(loc, "file should be nil on err")
 
 	loc, err = fs.NewLocation("", "invalid/location/")
-	o.Require().EqualError(err, utils.ErrBadAbsLocationPath, "error expected for invalid file")
+	o.Require().ErrorIs(err, utils.ErrBadAbsLocationPath, "error expected for invalid file")
 	o.Nil(loc, "file should be nil on err")
 
 	// success

--- a/backend/os/location.go
+++ b/backend/os/location.go
@@ -15,6 +15,11 @@ import (
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
+var (
+	errLocationRequired = errors.New("non-nil os.Location pointer is required")
+	errPathRequired     = errors.New("non-empty string path is required")
+)
+
 // Location implements the vfs.Location interface specific to OS fs.
 type Location struct {
 	name       string
@@ -26,11 +31,11 @@ type Location struct {
 // argument is expected to be a relative path to the location's current path.
 func (l *Location) NewFile(fileName string, opts ...options.NewFileOption) (vfs.File, error) {
 	if l == nil {
-		return nil, errors.New("non-nil os.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if fileName == "" {
-		return nil, errors.New("non-empty string filePath is required")
+		return nil, errPathRequired
 	}
 
 	fileName = filepath.ToSlash(fileName)
@@ -164,11 +169,11 @@ func (l *Location) String() string {
 // ChangeDir.
 func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 	if l == nil {
-		return nil, errors.New("non-nil os.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if relativePath == "" {
-		return nil, errors.New("non-empty string relativePath is required")
+		return nil, errPathRequired
 	}
 
 	if err := utils.ValidateRelativeLocationPath(relativePath); err != nil {
@@ -190,10 +195,10 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 //	loc, err := loc.NewLocation("../../")
 func (l *Location) ChangeDir(relativePath string) error {
 	if l == nil {
-		return errors.New("non-nil os.Location pointer is required")
+		return errLocationRequired
 	}
 	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
+		return errPathRequired
 	}
 	err := utils.ValidateRelativeLocationPath(relativePath)
 	if err != nil {

--- a/backend/s3/fileSystem.go
+++ b/backend/s3/fileSystem.go
@@ -16,6 +16,11 @@ import (
 const Scheme = "s3"
 const name = "AWS S3"
 
+var (
+	errFileSystemRequired       = errors.New("non-nil s3.FileSystem pointer is required")
+	errAuthorityAndNameRequired = errors.New("non-empty strings for authority and name are required")
+)
+
 // FileSystem implements vfs.FileSystem for the S3 file system.
 type FileSystem struct {
 	client  Client
@@ -44,11 +49,11 @@ func (fs *FileSystem) Retry() vfs.Retry {
 // NewFile function returns the s3 implementation of vfs.File.
 func (fs *FileSystem) NewFile(authorityStr, name string, opts ...options.NewFileOption) (vfs.File, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil s3.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || name == "" {
-		return nil, errors.New("non-empty strings for bucket and key are required")
+		return nil, errAuthorityAndNameRequired
 	}
 
 	if err := utils.ValidateAbsoluteFilePath(name); err != nil {
@@ -69,11 +74,11 @@ func (fs *FileSystem) NewFile(authorityStr, name string, opts ...options.NewFile
 // NewLocation function returns the s3 implementation of vfs.Location.
 func (fs *FileSystem) NewLocation(authorityStr, name string) (vfs.Location, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil s3.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || name == "" {
-		return nil, errors.New("non-empty strings for bucket and key are required")
+		return nil, errAuthorityAndNameRequired
 	}
 
 	if err := utils.ValidateAbsoluteLocationPath(name); err != nil {

--- a/backend/s3/fileSystem_test.go
+++ b/backend/s3/fileSystem_test.go
@@ -55,11 +55,11 @@ func (ts *fileSystemTestSuite) TestNewFile_Error() {
 	// test nil pointer
 	var nils3fs *FileSystem
 	_, err := nils3fs.NewFile("", "/path/to/file.txt")
-	ts.Require().EqualError(err, "non-nil s3.FileSystem pointer is required", "errors returned by NewFile")
+	ts.Require().ErrorIs(err, errFileSystemRequired, "errors returned by NewFile")
 
 	// test validation error
 	file, err := s3fs.NewFile("bucketName", "relative/path/to/file.txt")
-	ts.Require().EqualError(err, utils.ErrBadAbsFilePath, "errors returned by NewFile")
+	ts.Require().ErrorIs(err, utils.ErrBadAbsFilePath, "errors returned by NewFile")
 	ts.Nil(file, "NewFile shouldn't return a file")
 
 	filePath := ""
@@ -79,16 +79,16 @@ func (ts *fileSystemTestSuite) TestNewLocation_Error() {
 	// test nil pointer
 	var nils3fs *FileSystem
 	_, err := nils3fs.NewLocation("", "/path/to/")
-	ts.Require().EqualError(err, "non-nil s3.FileSystem pointer is required", "errors returned by NewLocation")
+	ts.Require().ErrorIs(err, errFileSystemRequired, "errors returned by NewLocation")
 
 	// test validation error
 	file, err := s3fs.NewLocation("bucketName", "relative/path/to/")
-	ts.Require().EqualError(err, utils.ErrBadAbsLocationPath, "errors returned by NewLocation")
+	ts.Require().ErrorIs(err, utils.ErrBadAbsLocationPath, "errors returned by NewLocation")
 	ts.Nil(file, "NewFile shouldn't return a file")
 
 	locPath := ""
 	file, err = s3fs.NewLocation("", locPath)
-	ts.Require().EqualError(err, "non-empty strings for bucket and key are required", "NewLocation(%s)", locPath)
+	ts.Require().ErrorIs(err, errAuthorityAndNameRequired, "NewLocation(%s)", locPath)
 	ts.Nil(file, "NewLocation(%s) shouldn't return a file", locPath)
 }
 

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -702,17 +702,18 @@ func (ts *fileTestSuite) TestUploadInputContentType() {
 }
 
 func (ts *fileTestSuite) TestNewFile() {
-	fs := &FileSystem{}
+	var fs *FileSystem
 	// fs is nil
 	_, err := fs.NewFile("", "")
-	ts.Require().Errorf(err, "non-nil s3.FileSystem pointer is required")
+	ts.Require().ErrorIs(err, errFileSystemRequired)
 
+	fs = &FileSystem{}
 	// bucket is ""
 	_, err = fs.NewFile("", "asdf")
-	ts.Require().Errorf(err, "non-empty strings for bucket and key are required")
+	ts.Require().ErrorIs(err, errAuthorityAndNameRequired)
 	// key is ""
 	_, err = fs.NewFile("asdf", "")
-	ts.Require().Errorf(err, "non-empty strings for bucket and key are required")
+	ts.Require().ErrorIs(err, errAuthorityAndNameRequired)
 
 	//
 	bucket := "mybucket"

--- a/backend/s3/location.go
+++ b/backend/s3/location.go
@@ -17,6 +17,11 @@ import (
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
+var (
+	errLocationRequired = errors.New("non-nil s3.Location pointer is required")
+	errPathRequired     = errors.New("non-empty string for path is required")
+)
+
 // Location implements the vfs.Location interface specific to S3 fs.
 type Location struct {
 	fileSystem *FileSystem
@@ -106,11 +111,11 @@ func (l *Location) Exists() (bool, error) {
 // ChangeDir, which, for the s3 implementation doesn't ever result in an error.
 func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 	if l == nil {
-		return nil, errors.New("non-nil s3.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if relativePath == "" {
-		return nil, errors.New("non-empty string relativePath is required")
+		return nil, errPathRequired
 	}
 
 	if err := utils.ValidateRelativeLocationPath(relativePath); err != nil {
@@ -132,11 +137,11 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 //	loc, err := loc.NewLocation("../../")
 func (l *Location) ChangeDir(relativePath string) error {
 	if l == nil {
-		return errors.New("non-nil s3.Location pointer is required")
+		return errLocationRequired
 	}
 
 	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
+		return errPathRequired
 	}
 
 	err := utils.ValidateRelativeLocationPath(relativePath)
@@ -157,11 +162,11 @@ func (l *Location) ChangeDir(relativePath string) error {
 // argument is expected to be a relative path to the location's current path.
 func (l *Location) NewFile(relFilePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if l == nil {
-		return nil, errors.New("non-nil s3.Location pointer is required")
+		return nil, errLocationRequired
 	}
 
 	if relFilePath == "" {
-		return nil, errors.New("non-empty string filePath is required")
+		return nil, errPathRequired
 	}
 
 	err := utils.ValidateRelativeFilePath(relFilePath)

--- a/backend/s3/location_test.go
+++ b/backend/s3/location_test.go
@@ -192,15 +192,15 @@ func (lt *locationTestSuite) TestNewFile() {
 	// test nil pointer
 	var nilLoc *Location
 	_, err = nilLoc.NewFile("/path/to/file.txt")
-	lt.Require().EqualError(err, "non-nil s3.Location pointer is required", "errors returned by NewFile")
+	lt.Require().ErrorIs(err, errLocationRequired, "errors returned by NewFile")
 
 	// test empty path error
 	_, err = loc.NewFile("")
-	lt.Require().EqualError(err, "non-empty string filePath is required", "errors returned by NewFile")
+	lt.Require().ErrorIs(err, errPathRequired, "errors returned by NewFile")
 
 	// test validation error
 	_, err = loc.NewFile("/absolute/path/to/file.txt")
-	lt.Require().EqualError(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
 
 	// new tests for location update
 	lt.Run("new file with relative path updates location", func() {
@@ -246,7 +246,7 @@ func (lt *locationTestSuite) TestChangeDir() {
 	// test nil Location
 	var nilLoc *Location
 	err := nilLoc.ChangeDir("path/to/")
-	lt.Require().EqualErrorf(err, "non-nil s3.Location pointer is required", "error expected for nil location")
+	lt.Require().ErrorIsf(err, errLocationRequired, "error expected for nil location")
 
 	auth, err := authority.NewAuthority("bucket")
 	lt.Require().NoError(err)
@@ -288,15 +288,15 @@ func (lt *locationTestSuite) TestNewLocation() {
 	// test nil pointer
 	var nilLoc *Location
 	_, err = nilLoc.NewLocation("/path/to/")
-	lt.Require().EqualError(err, "non-nil s3.Location pointer is required", "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, errLocationRequired, "errors returned by NewLocation")
 
 	// test empty path error
 	_, err = loc.NewLocation("")
-	lt.Require().EqualError(err, "non-empty string relativePath is required", "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, errPathRequired, "errors returned by NewLocation")
 
 	// test validation error
 	_, err = loc.NewLocation("/absolute/path/to/")
-	lt.Require().EqualError(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
 }
 
 func (lt *locationTestSuite) TestStringURI() {

--- a/backend/sftp/fileSystem.go
+++ b/backend/sftp/fileSystem.go
@@ -26,6 +26,11 @@ const defaultAutoDisconnectDuration = 10
 
 var defaultClientGetter func(authority.Authority, Options) (Client, io.Closer, error)
 
+var (
+	errFileSystemRequired       = errors.New("non-nil sftp.FileSystem pointer is required")
+	errAuthorityAndPathRequired = errors.New("non-empty string for authority and path are required")
+)
+
 // FileSystem implements vfs.FileSystem for the SFTP filesystem.
 type FileSystem struct {
 	options    Options
@@ -56,11 +61,11 @@ func (fs *FileSystem) Retry() vfs.Retry {
 // NewFile function returns the SFTP implementation of vfs.File.
 func (fs *FileSystem) NewFile(authorityStr, filePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil sftp.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
 	if authorityStr == "" || filePath == "" {
-		return nil, errors.New("non-empty string for authority and path are required")
+		return nil, errAuthorityAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteFilePath(filePath); err != nil {
@@ -81,11 +86,11 @@ func (fs *FileSystem) NewFile(authorityStr, filePath string, opts ...options.New
 // NewLocation function returns the SFTP implementation of vfs.Location.
 func (fs *FileSystem) NewLocation(authorityStr, locPath string) (vfs.Location, error) {
 	if fs == nil {
-		return nil, errors.New("non-nil sftp.FileSystem pointer is required")
+		return nil, errFileSystemRequired
 	}
 
-	if authorityStr == "" {
-		return nil, errors.New("non-empty string for authority is required")
+	if authorityStr == "" || locPath == "" {
+		return nil, errAuthorityAndPathRequired
 	}
 
 	if err := utils.ValidateAbsoluteLocationPath(locPath); err != nil {

--- a/backend/sftp/fileSystem_test.go
+++ b/backend/sftp/fileSystem_test.go
@@ -50,11 +50,11 @@ func (ts *fileSystemTestSuite) TestNewFile_Error() {
 	// test nil pointer
 	var nilsftpfs *FileSystem
 	_, err := nilsftpfs.NewFile("host.com", "/path/to/file.txt")
-	ts.Require().EqualError(err, "non-nil sftp.FileSystem pointer is required", "errors returned by NewFile")
+	ts.Require().ErrorIs(err, errFileSystemRequired, "errors returned by NewFile")
 
 	// test validation error
 	file, err := ts.sftpfs.NewFile("host.com", "relative/path/to/file.txt")
-	ts.Require().EqualError(err, utils.ErrBadAbsFilePath, "errors returned by NewFile")
+	ts.Require().ErrorIs(err, utils.ErrBadAbsFilePath, "errors returned by NewFile")
 	ts.Nil(file, "NewFile shouldn't return a file")
 
 	filePath := ""
@@ -64,7 +64,7 @@ func (ts *fileSystemTestSuite) TestNewFile_Error() {
 
 	filePath = "/some/file.txt"
 	file, err = ts.sftpfs.NewFile("", filePath)
-	ts.Require().EqualError(err, "non-empty string for authority and path are required", "bad authority")
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired, "bad authority")
 	ts.Nil(file, "NewFile(%s) shouldn't return a file", filePath)
 }
 
@@ -79,21 +79,21 @@ func (ts *fileSystemTestSuite) TestNewLocation_Error() {
 	// test nil pointer
 	var nilsftpfs *FileSystem
 	_, err := nilsftpfs.NewLocation("somehost.com", "/path/to/")
-	ts.Require().EqualError(err, "non-nil sftp.FileSystem pointer is required", "errors returned by NewLocation")
+	ts.Require().ErrorIs(err, errFileSystemRequired, "errors returned by NewLocation")
 
 	// test validation error
 	file, err := ts.sftpfs.NewLocation("host.com", "relative/path/to/")
-	ts.Require().EqualError(err, utils.ErrBadAbsLocationPath, "errors returned by NewLocation")
+	ts.Require().ErrorIs(err, utils.ErrBadAbsLocationPath, "errors returned by NewLocation")
 	ts.Nil(file, "NewFile shouldn't return a file")
 
 	locPath := ""
 	file, err = ts.sftpfs.NewLocation("host.com", locPath)
-	ts.Require().EqualError(err, "absolute location path is invalid - must include leading and trailing slashes", "NewLocation(%s)", locPath)
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired, "NewLocation(%s)", locPath)
 	ts.Nil(file, "NewLocation(%s) shouldn't return a file", locPath)
 
 	locPath = "/path/"
 	file, err = ts.sftpfs.NewLocation("", locPath)
-	ts.Require().EqualError(err, "non-empty string for authority is required", "NewLocation(%s)", locPath)
+	ts.Require().ErrorIs(err, errAuthorityAndPathRequired, "NewLocation(%s)", locPath)
 	ts.Nil(file, "NewLocation(%s) shouldn't return a file", locPath)
 }
 

--- a/backend/sftp/file_test.go
+++ b/backend/sftp/file_test.go
@@ -905,17 +905,18 @@ func (ts *fileTestSuite) TestStringer() {
 }
 
 func (ts *fileTestSuite) TestNewFile() {
-	fs := &FileSystem{}
+	var fs *FileSystem
 	// fs is nil
 	_, err := fs.NewFile("user@host.com", "")
-	ts.Require().Errorf(err, "non-nil sftp.FileSystem pointer is required")
+	ts.Require().ErrorIs(err, errFileSystemRequired)
 
+	fs = &FileSystem{}
 	// authority is ""
 	_, err = fs.NewFile("", "asdf")
-	ts.Require().Errorf(err, "non-empty strings for bucket and key are required")
+	ts.Require().Error(err)
 	// path is ""
 	_, err = fs.NewFile("user@host.com", "")
-	ts.Require().Errorf(err, "non-empty strings for bucket and key are required")
+	ts.Require().Error(err)
 
 	authorityStr := "user@host.com"
 	key := "/path/to/file"

--- a/backend/sftp/location.go
+++ b/backend/sftp/location.go
@@ -14,6 +14,11 @@ import (
 	"github.com/c2fo/vfs/v7/utils/authority"
 )
 
+var (
+	errLocationRequired = errors.New("non-nil sftp.Location pointer receiver is required")
+	errPathRequired     = errors.New("non-empty string relativePath is required")
+)
+
 // Location implements the vfs.Location interface specific to sftp fs.
 type Location struct {
 	fileSystem *FileSystem
@@ -150,11 +155,11 @@ func (l *Location) Exists() (bool, error) {
 // relativePath argument, returning the resulting location.
 func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 	if l == nil {
-		return nil, errors.New("non-nil sftp.Location pointer receiver is required")
+		return nil, errLocationRequired
 	}
 
 	if relativePath == "" {
-		return nil, errors.New("non-empty string relativePath is required")
+		return nil, errPathRequired
 	}
 
 	if err := utils.ValidateRelativeLocationPath(relativePath); err != nil {
@@ -176,11 +181,11 @@ func (l *Location) NewLocation(relativePath string) (vfs.Location, error) {
 //	loc, err := loc.NewLocation("../../")
 func (l *Location) ChangeDir(relativePath string) error {
 	if l == nil {
-		return errors.New("non-nil sftp.Location pointer receiver is required")
+		return errLocationRequired
 	}
 
 	if relativePath == "" {
-		return errors.New("non-empty string relativePath is required")
+		return errPathRequired
 	}
 
 	err := utils.ValidateRelativeLocationPath(relativePath)
@@ -201,11 +206,11 @@ func (l *Location) ChangeDir(relativePath string) error {
 // argument is expected to be a relative path to the location's current path.
 func (l *Location) NewFile(relFilePath string, opts ...options.NewFileOption) (vfs.File, error) {
 	if l == nil {
-		return nil, errors.New("non-nil sftp.Location pointer receiver is required")
+		return nil, errLocationRequired
 	}
 
 	if relFilePath == "" {
-		return nil, errors.New("non-empty string filePath is required")
+		return nil, errPathRequired
 	}
 
 	err := utils.ValidateRelativeFilePath(relFilePath)

--- a/backend/sftp/location_test.go
+++ b/backend/sftp/location_test.go
@@ -206,15 +206,15 @@ func (lt *locationTestSuite) TestNewFile() {
 	// test nil pointer
 	var nilLoc *Location
 	_, err = nilLoc.NewFile("/path/to/file.txt")
-	lt.Require().EqualError(err, "non-nil sftp.Location pointer receiver is required", "errors returned by NewFile")
+	lt.Require().ErrorIs(err, errLocationRequired, "errors returned by NewFile")
 
 	// test empty path error
 	_, err = loc.NewFile("")
-	lt.Require().EqualError(err, "non-empty string filePath is required", "errors returned by NewFile")
+	lt.Require().ErrorIs(err, errPathRequired, "errors returned by NewFile")
 
 	// test validation error
 	_, err = loc.NewFile("/absolute/path/to/file.txt")
-	lt.Require().EqualError(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelFilePath, "errors returned by NewLocation")
 
 	// new tests for location update
 	lt.Run("new file with relative path updates location", func() {
@@ -279,7 +279,7 @@ func (lt *locationTestSuite) TestChangeDir() {
 	// test nil Location
 	var nilLoc *Location
 	err := nilLoc.ChangeDir("path/to/")
-	lt.Require().EqualErrorf(err, "non-nil sftp.Location pointer receiver is required", "error expected for nil location")
+	lt.Require().ErrorIs(err, errLocationRequired, "error expected for nil location")
 
 	loc := &Location{fileSystem: lt.sftpfs, path: "/", authority: authority.Authority{}}
 
@@ -319,15 +319,15 @@ func (lt *locationTestSuite) TestNewLocation() {
 	// test nil pointer
 	var nilLoc *Location
 	_, err = nilLoc.NewLocation("/path/to/")
-	lt.Require().EqualError(err, "non-nil sftp.Location pointer receiver is required", "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, errLocationRequired, "errors returned by NewLocation")
 
 	// test empty path error
 	_, err = loc.NewLocation("")
-	lt.Require().EqualError(err, "non-empty string relativePath is required", "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, errPathRequired, "errors returned by NewLocation")
 
 	// test validation error
 	_, err = loc.NewLocation("/absolute/path/to/")
-	lt.Require().EqualError(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
+	lt.Require().ErrorIs(err, utils.ErrBadRelLocationPath, "errors returned by NewLocation")
 }
 
 func (lt *locationTestSuite) TestDeleteFile() {

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -6,22 +6,29 @@
     import "github.com/c2fo/vfs/v7/utils"
 ```
 
+#### Error Variables
+
+```go
+var (
+    // ErrBadAbsFilePath is returned when a file path is not absolute
+    ErrBadAbsFilePath = errors.New("absolute file path is invalid - must include leading slash and may not include trailing slash")
+    // ErrBadRelFilePath is returned when a file path is not relative
+    ErrBadRelFilePath = errors.New("relative file path is invalid - may not include leading or trailing slashes")
+    // ErrBadAbsLocationPath is returned when a file path is not absolute
+    ErrBadAbsLocationPath = errors.New("absolute location path is invalid - must include leading and trailing slashes")
+    // ErrBadRelLocationPath is returned when a file path is not relative
+    ErrBadRelLocationPath = errors.New("relative location path is invalid - may not include leading slash but must include trailing slash")
+    // ErrBadPrefix is returned when a prefix is not relative or ends in / or is empty
+    ErrBadPrefix = errors.New("prefix is invalid - may not include leading or trailing slashes and may not be empty")
+)
+```
+
 #### Error Constants
 
 ```go
 const (
-	// ErrBadAbsFilePath constant is returned when a file path is not absolute
-	ErrBadAbsFilePath = "absolute file path is invalid - must include leading slash and may not include trailing slash"
-	// ErrBadRelFilePath constant is returned when a file path is not relative
-	ErrBadRelFilePath = "relative file path is invalid - may not include leading or trailing slashes"
-	// ErrBadAbsLocationPath constant is returned when a file path is not absolute
-	ErrBadAbsLocationPath = "absolute location path is invalid - must include leading and trailing slashes"
-	// ErrBadRelLocationPath constant is returned when a file path is not relative
-	ErrBadRelLocationPath = "relative location path is invalid - may not include leading slash but must include trailing slash"
-	// TouchCopyMinBufferSize min buffer size used in TouchCopyBuffered in bytes
-	ErrBadPrefix = "prefix is invalid - may not include leading or trailing slashes and may not be empty"
-	// TouchCopyMinBufferSize min buffer size used in TouchCopyBuffered in bytes
-	TouchCopyMinBufferSize = 262144
+    // TouchCopyMinBufferSize min buffer size used in TouchCopyBuffered in bytes
+    TouchCopyMinBufferSize = 262144
 )
 ```
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,17 +15,20 @@ import (
 	"github.com/c2fo/vfs/v7"
 )
 
+var (
+	// ErrBadAbsFilePath is returned when a file path is not absolute
+	ErrBadAbsFilePath = errors.New("absolute file path is invalid - must include leading slash and may not include trailing slash")
+	// ErrBadRelFilePath is returned when a file path is not relative
+	ErrBadRelFilePath = errors.New("relative file path is invalid - may not include leading or trailing slashes")
+	// ErrBadAbsLocationPath is returned when a file path is not absolute
+	ErrBadAbsLocationPath = errors.New("absolute location path is invalid - must include leading and trailing slashes")
+	// ErrBadRelLocationPath is returned when a file path is not relative
+	ErrBadRelLocationPath = errors.New("relative location path is invalid - may not include leading slash but must include trailing slash")
+	// ErrBadPrefix is returned when a prefix is not relative or ends in / or is empty
+	ErrBadPrefix = errors.New("prefix is invalid - may not include leading or trailing slashes and may not be empty")
+)
+
 const (
-	// ErrBadAbsFilePath constant is returned when a file path is not absolute
-	ErrBadAbsFilePath = "absolute file path is invalid - must include leading slash and may not include trailing slash"
-	// ErrBadRelFilePath constant is returned when a file path is not relative
-	ErrBadRelFilePath = "relative file path is invalid - may not include leading or trailing slashes"
-	// ErrBadAbsLocationPath constant is returned when a file path is not absolute
-	ErrBadAbsLocationPath = "absolute location path is invalid - must include leading and trailing slashes"
-	// ErrBadRelLocationPath constant is returned when a file path is not relative
-	ErrBadRelLocationPath = "relative location path is invalid - may not include leading slash but must include trailing slash"
-	// ErrBadPrefix constant is returned when a prefix is not relative or ends in / or is empty
-	ErrBadPrefix = "prefix is invalid - may not include leading or trailing slashes and may not be empty"
 	// TouchCopyMinBufferSize min buffer size used in TouchCopyBuffered in bytes
 	TouchCopyMinBufferSize = 262144
 )
@@ -49,7 +52,7 @@ func RemoveLeadingSlash(path string) string {
 // ValidateAbsoluteFilePath ensures that a file path has a leading slash but not a trailing slash
 func ValidateAbsoluteFilePath(name string) error {
 	if !strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") {
-		return errors.New(ErrBadAbsFilePath)
+		return ErrBadAbsFilePath
 	}
 	return nil
 }
@@ -57,7 +60,7 @@ func ValidateAbsoluteFilePath(name string) error {
 // ValidateRelativeFilePath ensures that a file path has neither leading nor trailing slashes
 func ValidateRelativeFilePath(name string) error {
 	if name == "" || name == "." || strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") {
-		return errors.New(ErrBadRelFilePath)
+		return ErrBadRelFilePath
 	}
 	return nil
 }
@@ -65,7 +68,7 @@ func ValidateRelativeFilePath(name string) error {
 // ValidateAbsoluteLocationPath ensure that a file path has both leading and trailing slashes
 func ValidateAbsoluteLocationPath(name string) error {
 	if !strings.HasPrefix(name, "/") || !strings.HasSuffix(name, "/") {
-		return errors.New(ErrBadAbsLocationPath)
+		return ErrBadAbsLocationPath
 	}
 	return nil
 }
@@ -73,7 +76,7 @@ func ValidateAbsoluteLocationPath(name string) error {
 // ValidateRelativeLocationPath ensure that a file path has no leading slash but has a trailing slash
 func ValidateRelativeLocationPath(name string) error {
 	if strings.HasPrefix(name, "/") || !strings.HasSuffix(name, "/") {
-		return errors.New(ErrBadRelLocationPath)
+		return ErrBadRelLocationPath
 	}
 	return nil
 }
@@ -82,7 +85,7 @@ func ValidateRelativeLocationPath(name string) error {
 // may not be empty but unlike relative file path, *may* be simply "."
 func ValidatePrefix(prefix string) error {
 	if prefix == "" || strings.HasPrefix(prefix, "/") || strings.HasSuffix(prefix, "/") {
-		return errors.New(ErrBadPrefix)
+		return ErrBadPrefix
 	}
 	return nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -233,7 +233,7 @@ func (s *utilsSuite) TestValidateAbsFilePath() {
 		s.Run(validationTest.message, func() {
 			err := utils.ValidateAbsoluteFilePath(validationTest.path)
 			if !validationTest.passExpected {
-				s.Require().EqualError(err, utils.ErrBadAbsFilePath, validationTest.message)
+				s.Require().ErrorIs(err, utils.ErrBadAbsFilePath, validationTest.message)
 			} else {
 				s.Require().NoError(err, validationTest.message)
 			}
@@ -299,7 +299,7 @@ func (s *utilsSuite) TestValidateAbsLocationPath() {
 		s.Run(validationTest.message, func() {
 			err := utils.ValidateAbsoluteLocationPath(validationTest.path)
 			if !validationTest.passExpected {
-				s.Require().EqualError(err, utils.ErrBadAbsLocationPath, validationTest.message)
+				s.Require().ErrorIs(err, utils.ErrBadAbsLocationPath, validationTest.message)
 			} else {
 				s.Require().NoError(err, validationTest.message)
 			}
@@ -365,7 +365,7 @@ func (s *utilsSuite) TestValidateRelFilePath() {
 		s.Run(validationTest.message, func() {
 			err := utils.ValidateRelativeFilePath(validationTest.path)
 			if !validationTest.passExpected {
-				s.Require().EqualError(err, utils.ErrBadRelFilePath, validationTest.message)
+				s.Require().ErrorIs(err, utils.ErrBadRelFilePath, validationTest.message)
 			} else {
 				s.Require().NoError(err, validationTest.message)
 			}
@@ -431,7 +431,7 @@ func (s *utilsSuite) TestValidateRelLocationPath() {
 		s.Run(validationTest.message, func() {
 			err := utils.ValidateRelativeLocationPath(validationTest.path)
 			if !validationTest.passExpected {
-				s.Require().EqualError(err, utils.ErrBadRelLocationPath, validationTest.message)
+				s.Require().ErrorIs(err, utils.ErrBadRelLocationPath, validationTest.message)
 			} else {
 				s.Require().NoError(err, validationTest.message)
 			}
@@ -521,7 +521,7 @@ func (s *utilsSuite) TestValidatePrefix() {
 		s.Run(validationTest.message, func() {
 			err := utils.ValidatePrefix(validationTest.prefix)
 			if !validationTest.passExpected {
-				s.Require().EqualError(err, utils.ErrBadPrefix, validationTest.message)
+				s.Require().ErrorIs(err, utils.ErrBadPrefix, validationTest.message)
 			} else {
 				s.Require().NoError(err, validationTest.message)
 			}


### PR DESCRIPTION
Much better to define sentinel errors than error string constants. This allows users to use `errors.Is` and the corresponding `ErrorIs` in testify. 