### PR TITLE
Use `any` keyword consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Style
+- Use the `any` keyword where possible.
 
 ## [v7.10.0] - 2025-10-07
 ### Security

--- a/backend/mem/fileSystem.go
+++ b/backend/mem/fileSystem.go
@@ -17,7 +17,7 @@ const name = "In-Memory FileSystem"
 
 type fsObject struct {
 	isFile bool
-	i      interface{}
+	i      any
 }
 type objMap map[string]*fsObject
 

--- a/backend/s3/fileSystem.go
+++ b/backend/s3/fileSystem.go
@@ -148,7 +148,7 @@ func (fs *FileSystem) WithOptions(opts vfs.Options) *FileSystem {
 // instead of:
 //
 //	fs := s3.NewFileSystem().WithClient(client)
-func (fs *FileSystem) WithClient(client interface{}) *FileSystem {
+func (fs *FileSystem) WithClient(client any) *FileSystem {
 	if c, ok := client.(Client); ok {
 		fs.client = c
 		fs.options = Options{}

--- a/backend/sftp/concurrency_test.go
+++ b/backend/sftp/concurrency_test.go
@@ -83,7 +83,7 @@ func (s *SFTPConcurrencyTestSuite) TestConcurrentFailedConnections() {
 	// Start multiple goroutines that will all fail to connect
 	const numGoroutines = 10
 	var wg sync.WaitGroup
-	panicChan := make(chan interface{}, numGoroutines)
+	panicChan := make(chan any, numGoroutines)
 	errorChan := make(chan error, numGoroutines)
 
 	for range numGoroutines {
@@ -107,7 +107,7 @@ func (s *SFTPConcurrencyTestSuite) TestConcurrentFailedConnections() {
 	close(errorChan)
 
 	// Collect any panics that occurred
-	panics := make([]interface{}, 0, len(panicChan))
+	panics := make([]any, 0, len(panicChan))
 	for panic := range panicChan {
 		panics = append(panics, panic)
 	}
@@ -176,7 +176,7 @@ func (s *SFTPConcurrencyTestSuite) TestTimerCleanupRobustness() {
 	// Start multiple operations that will fail but might trigger the timer
 	const numOperations = 10
 	var wg sync.WaitGroup
-	panicChan := make(chan interface{}, numOperations)
+	panicChan := make(chan any, numOperations)
 
 	for range numOperations {
 		wg.Add(1)
@@ -204,7 +204,7 @@ func (s *SFTPConcurrencyTestSuite) TestTimerCleanupRobustness() {
 	close(panicChan)
 
 	// Collect any panics that occurred
-	panics := make([]interface{}, 0, len(panicChan))
+	panics := make([]any, 0, len(panicChan))
 	for panic := range panicChan {
 		panics = append(panics, panic)
 	}

--- a/backend/sftp/fileSystem.go
+++ b/backend/sftp/fileSystem.go
@@ -192,7 +192,7 @@ func (fs *FileSystem) WithOptions(opts vfs.Options) *FileSystem {
 // instead of:
 //
 //	fs := sftp.NewFileSystem().WithClient(client)
-func (fs *FileSystem) WithClient(client interface{}) *FileSystem {
+func (fs *FileSystem) WithClient(client any) *FileSystem {
 	switch client.(type) {
 	case Client, *ssh.Client:
 		fs.sftpclient = client.(Client)

--- a/backend/sftp/options_test.go
+++ b/backend/sftp/options_test.go
@@ -517,7 +517,7 @@ func (o *optionsSuite) TestMarshalOptions() {
 	pw := "secret1234"
 	kh := "/path/to/known_hosts"
 
-	opts := map[string]interface{}{
+	opts := map[string]any{
 		"password":    pw,
 		"keyFilePath": kh,
 	}

--- a/docs/ftp.md
+++ b/docs/ftp.md
@@ -40,7 +40,7 @@ ftp can be augmented with some implementation-specific methods. [Backend](backen
 [vfs.FileSystem](../README.md#type-filesystem) interface, so it would have to be cast as ftp.FileSystem to use
 them.
 
-These methods are chainable: (*FileSystem) WithClient(client interface{})
+These methods are chainable: (*FileSystem) WithClient(client any)
 *FileSystem (*FileSystem) WithOptions(opts vfs.Options) *FileSystem
 
 ```go

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -320,7 +320,7 @@ Scheme return "s3" as the initial part of a file URI ie: s3://
 #### func (*FileSystem) WithClient
 
 ```go
-func (fs *FileSystem) WithClient(client interface{}) *FileSystem
+func (fs *FileSystem) WithClient(client any) *FileSystem
 ```
 WithClient passes in an s3 client and returns the filesystem (chainable)
 

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -45,7 +45,7 @@ them.
 
 These methods are chainable:
 
-* `(*FileSystem) WithClient(client interface{})*FileSystem`
+* `(*FileSystem) WithClient(client any)*FileSystem`
 * `(*FileSystem) WithOptions(opts vfs.Options) *FileSystem`
 
 ```go
@@ -451,7 +451,7 @@ Scheme return "sftp" as the initial part of a file URI ie: sftp://
 #### func (*FileSystem) WithClient
 
 ```go
-func (fs *FileSystem) WithClient(client interface{}) *FileSystem
+func (fs *FileSystem) WithClient(client any) *FileSystem
 ```
 WithClient passes in an sftp client and returns the filesystem (chainable)
 

--- a/vfs.go
+++ b/vfs.go
@@ -248,7 +248,7 @@ type File interface {
 // Use the specific options struct for the file system with the NewFileSystem function:
 //
 //	fs := s3.NewFileSystem(s3.WithOptions(s3Opts))
-type Options interface{}
+type Options any
 
 // Retry is a function that can be used to wrap any operation into a definable retry operation. The wrapped argument
 // is called by the underlying VFS implementation.


### PR DESCRIPTION
Adopt the `any` keyword in place of `interface{}` everywhere.