### PR TITLE
Avoid type assert and type convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use context from `testing.T` introduced in Go 1.24.
 - Define more sentinel errors for more ergonomic error checking.
 - Use typed expectations consistently for added type safety.
+- Avoid type assert and type convert where possible.
 ### Fixed
 - Use walrus assignment where possible.
 - Use the `any` keyword where possible.

--- a/backend/azure/file.go
+++ b/backend/azure/file.go
@@ -39,7 +39,7 @@ func (f *File) Close() error {
 			f.isDirty = false
 		}()
 
-		client, err := f.Location().FileSystem().(*FileSystem).Client()
+		client, err := f.location.fileSystem.Client()
 		if err != nil {
 			return utils.WrapCloseError(err)
 		}
@@ -125,7 +125,7 @@ func (f *File) String() string {
 
 // Exists returns true/false if the file exists/does not exist on Azure
 func (f *File) Exists() (bool, error) {
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return false, utils.WrapExistsError(err)
 	}
@@ -186,7 +186,7 @@ func (f *File) CopyToFile(file vfs.File) (err error) {
 	azFile, ok := file.(*File)
 	if ok {
 		if f.isSameAuth(azFile) {
-			client, err := f.Location().FileSystem().(*FileSystem).Client()
+			client, err := f.location.fileSystem.Client()
 			if err != nil {
 				return utils.WrapCopyToFileError(err)
 			}
@@ -197,8 +197,8 @@ func (f *File) CopyToFile(file vfs.File) (err error) {
 	// Otherwise, use TouchCopyBuffered using io.CopyBuffer
 	fileBufferSize := 0
 
-	if fs, ok := f.Location().FileSystem().(*FileSystem); ok {
-		fileBufferSize = fs.options.FileBufferSize
+	if f.location.fileSystem.options.FileBufferSize > 0 {
+		fileBufferSize = f.location.fileSystem.options.FileBufferSize
 	}
 
 	if terr := utils.TouchCopyBuffered(file, f, fileBufferSize); terr != nil {
@@ -240,7 +240,7 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 		return utils.WrapDeleteError(err)
 	}
 
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return utils.WrapDeleteError(err)
 	}
@@ -267,7 +267,7 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 
 // LastModified returns the last modified time as a time.Time
 func (f *File) LastModified() (*time.Time, error) {
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return nil, utils.WrapLastModifiedError(err)
 	}
@@ -280,7 +280,7 @@ func (f *File) LastModified() (*time.Time, error) {
 
 // Size returns the size of the blob
 func (f *File) Size() (uint64, error) {
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return 0, utils.WrapSizeError(err)
 	}
@@ -309,7 +309,7 @@ func (f *File) Touch() error {
 		return utils.WrapTouchError(err)
 	}
 
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return utils.WrapTouchError(err)
 	}
@@ -352,7 +352,7 @@ func (f *File) URI() string {
 
 func (f *File) checkTempFile() error {
 	if f.tempFile == nil {
-		client, err := f.Location().FileSystem().(*FileSystem).Client()
+		client, err := f.location.fileSystem.Client()
 		if err != nil {
 			return err
 		}
@@ -394,7 +394,7 @@ func (f *File) checkTempFile() error {
 }
 
 func (f *File) isSameAuth(target *File) bool {
-	sourceOptions := f.Location().FileSystem().(*FileSystem).options
-	targetOptions := target.Location().FileSystem().(*FileSystem).options
+	sourceOptions := f.location.fileSystem.options
+	targetOptions := target.location.fileSystem.options
 	return sourceOptions.AccountKey == targetOptions.AccountKey
 }

--- a/backend/azure/location_test.go
+++ b/backend/azure/location_test.go
@@ -163,7 +163,7 @@ func (s *LocationTestSuite) TestNewLocation_NilReceiver() {
 func (s *LocationTestSuite) TestChangeDir() {
 	l, err := NewFileSystem().NewLocation("test-container", "/")
 	s.Require().NoError(err)
-	l = l.(*Location)
+
 	err = l.ChangeDir("some-dir/")
 	s.Require().NoError(err)
 	s.Equal("/some-dir/", l.Path())
@@ -174,21 +174,21 @@ func (s *LocationTestSuite) TestChangeDir() {
 
 	l, err = NewFileSystem().NewLocation("test-container", "/")
 	s.Require().NoError(err)
-	l = l.(*Location)
+
 	err = l.ChangeDir("/test-dir/")
 	s.Require().ErrorIs(err, utils.ErrBadRelLocationPath,
 		"The path begins with a slash and therefore is not a relative path so this should return an error")
 
 	l, err = NewFileSystem().NewLocation("test-container", "/")
 	s.Require().NoError(err)
-	l = l.(*Location)
+
 	err = l.ChangeDir("test-dir")
 	s.Require().ErrorIs(err, utils.ErrBadRelLocationPath,
 		"The path does not end with a slash and therefore is not a relative path so this should return an error")
 
 	l, err = NewFileSystem().NewLocation("test-container", "/")
 	s.Require().NoError(err)
-	l = l.(*Location)
+
 	err = l.ChangeDir("")
 	s.Require().ErrorIs(err, utils.ErrBadRelLocationPath,
 		"An empty relative path does not end with a slash and therefore is not a valid relative path so this should return an error")

--- a/backend/ftp/dataconn_test.go
+++ b/backend/ftp/dataconn_test.go
@@ -49,13 +49,13 @@ func (s *dataConnSuite) SetupTest() {
 
 func (s *dataConnSuite) TestGetDataConn_alreadyExists() {
 	// dataconn already exists
-	s.ftpFile.Location().FileSystem().(*FileSystem).dataconn = &dataConn{
+	s.ftpFile.location.fileSystem.dataconn = &dataConn{
 		mode: types.OpenRead,
 	}
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenRead,
 	)
@@ -72,7 +72,7 @@ func (s *dataConnSuite) TestGetDataConn_openForRead() {
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenRead,
 	)
@@ -83,11 +83,11 @@ func (s *dataConnSuite) TestGetDataConn_openForRead() {
 func (s *dataConnSuite) TestGetDataConn_errorClientSetup() {
 	// dataconn is nil - error getting client
 	defaultClientGetter = clientGetterReturnsError
-	s.ftpFile.Location().FileSystem().(*FileSystem).ftpclient = nil
+	s.ftpFile.location.fileSystem.ftpclient = nil
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenRead,
 	)
@@ -110,7 +110,7 @@ func (s *dataConnSuite) TestGetDataConn_ReadError() {
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenRead,
 	)
@@ -136,7 +136,7 @@ func (s *dataConnSuite) TestGetDataConn_WriteLocationNotExists() {
 	_, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenWrite,
 	)
@@ -160,7 +160,7 @@ func (s *dataConnSuite) TestGetDataConn_WriteLocationNotExistsFails() {
 	_, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenWrite,
 	)
@@ -189,7 +189,7 @@ func (s *dataConnSuite) TestGetDataConn_errorWriting() {
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenWrite,
 	)
@@ -217,7 +217,7 @@ func (s *dataConnSuite) TestGetDataConn_writeSuccess() {
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenWrite,
 	)
@@ -233,11 +233,11 @@ func (s *dataConnSuite) TestGetDataConn_readAfterWriteError() {
 	fakedconn := NewFakeDataConn(types.OpenWrite)
 	closeErr := errors.New("some close err")
 	fakedconn.AssertCloseErr(closeErr)
-	s.ftpFile.Location().FileSystem().(*FileSystem).dataconn = fakedconn
+	s.ftpFile.location.fileSystem.dataconn = fakedconn
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenRead,
 	)
@@ -252,7 +252,7 @@ func (s *dataConnSuite) TestGetDataConn_writeAfterReadSuccess() {
 		Name: "some",
 		Type: _ftp.EntryTypeFolder,
 	}}
-	s.ftpFile.Location().FileSystem().(*FileSystem).dataconn = &dataConn{
+	s.ftpFile.location.fileSystem.dataconn = &dataConn{
 		mode: types.OpenRead,
 		R:    io.NopCloser(strings.NewReader("")),
 	}
@@ -267,7 +267,7 @@ func (s *dataConnSuite) TestGetDataConn_writeAfterReadSuccess() {
 	dc, err := getDataConn(
 		s.T().Context(),
 		authority.Authority{},
-		s.ftpFile.Location().FileSystem().(*FileSystem),
+		s.ftpFile.location.fileSystem,
 		s.ftpFile,
 		types.OpenWrite,
 	)

--- a/backend/ftp/location_test.go
+++ b/backend/ftp/location_test.go
@@ -228,17 +228,19 @@ func (lt *locationTestSuite) TestListByPrefix() {
 	lt.Require().ErrorIs(err, utils.ErrBadPrefix, "err should be correct type")
 	lt.Equal(expectedEmptyStringSlice, fileList, "fileList should be empty string slice")
 
+	ftpLoc := loc.(*Location)
+
 	// error getting client
 	defaultClientGetter = clientGetterReturnsError
-	loc.(*Location).fileSystem.WithClient(nil)
-	loc.(*Location).fileSystem.dataconn = nil
+	ftpLoc.fileSystem.WithClient(nil)
+	ftpLoc.fileSystem.dataconn = nil
 	fileList, err = loc.ListByPrefix(prefix)
 	lt.Require().Error(err, "error expected")
 	lt.Require().ErrorIs(err, errClientGetter, "err should be correct type")
 	lt.Equal(expectedEmptyStringSlice, fileList, "fileList should be empty string slice")
 
 	// error calling client.List()
-	loc.(*Location).fileSystem.WithClient(lt.client)
+	ftpLoc.fileSystem.WithClient(lt.client)
 	listErr := errors.New("some error")
 	lt.client.EXPECT().
 		List(locPath).

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -128,7 +128,7 @@ func (f *File) CopyToFile(file vfs.File) (err error) {
 		input := f.getCopyObjectInput(tf)
 		// if input is not nil, use it to natively copy object
 		if input != nil {
-			client, err := f.Location().FileSystem().(*FileSystem).Client()
+			client, err := f.location.fileSystem.Client()
 			if err != nil {
 				return utils.WrapCopyToFileError(err)
 			}
@@ -141,7 +141,7 @@ func (f *File) CopyToFile(file vfs.File) (err error) {
 	}
 
 	// Otherwise, use TouchCopyBuffered using io.CopyBuffer
-	fileBufferSize := f.Location().FileSystem().(*FileSystem).options.FileBufferSize
+	fileBufferSize := f.location.fileSystem.options.FileBufferSize
 
 	if err := utils.TouchCopyBuffered(file, f, fileBufferSize); err != nil {
 		return utils.WrapCopyToFileError(err)
@@ -202,7 +202,7 @@ func (f *File) Delete(opts ...options.DeleteOption) error {
 		return utils.WrapDeleteError(err)
 	}
 
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return utils.WrapDeleteError(err)
 	}
@@ -328,7 +328,7 @@ func (f *File) tempToS3() error {
 	}
 
 	// write tempFileWriter to s3
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return err
 	}
@@ -546,7 +546,7 @@ func (f *File) getHeadObject() (*s3.HeadObjectOutput, error) {
 		Key:    aws.String(f.key),
 		Bucket: aws.String(bucket),
 	}
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (f *File) getCopyObjectInput(targetFile *File) *s3.CopyObjectInput {
 		copyInput.ContentType = aws.String(contentType)
 	}
 
-	if f.Location().FileSystem().(*FileSystem).options.DisableServerSideEncryption {
+	if f.location.fileSystem.options.DisableServerSideEncryption {
 		copyInput.ServerSideEncryption = ""
 	}
 
@@ -602,8 +602,8 @@ func (f *File) getCopyObjectInput(targetFile *File) *s3.CopyObjectInput {
 }
 
 func (f *File) isSameAuth(targetFile *File) (bool, types.ObjectCannedACL) {
-	fileOptions := f.Location().FileSystem().(*FileSystem).options
-	targetOptions := targetFile.Location().FileSystem().(*FileSystem).options
+	fileOptions := f.location.fileSystem.options
+	targetOptions := targetFile.location.fileSystem.options
 
 	if (fileOptions == Options{}) && (targetOptions == Options{}) {
 		// if both opts are nil, we must be using the default credentials
@@ -625,7 +625,7 @@ func (f *File) isSameAuth(targetFile *File) (bool, types.ObjectCannedACL) {
 }
 
 func (f *File) copyS3ToLocalTempReader(tmpFile *os.File) error {
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return err
 	}
@@ -651,11 +651,11 @@ func uploadInput(f *File) *s3.PutObjectInput {
 		ServerSideEncryption: types.ServerSideEncryptionAes256,
 	}
 
-	if f.Location().FileSystem().(*FileSystem).options.DisableServerSideEncryption {
+	if f.location.fileSystem.options.DisableServerSideEncryption {
 		input.ServerSideEncryption = ""
 	}
 
-	opts := f.Location().FileSystem().(*FileSystem).options
+	opts := f.location.fileSystem.options
 	if opts.ACL != "" {
 		input.ACL = opts.ACL
 	}
@@ -728,7 +728,7 @@ func (f *File) getReader() (io.ReadCloser, error) {
 				}
 
 				// Get the client
-				client, err := f.Location().FileSystem().(*FileSystem).Client()
+				client, err := f.location.fileSystem.Client()
 				if err != nil {
 					return nil, err
 				}
@@ -800,7 +800,7 @@ func (f *File) getS3Writer() (*io.PipeWriter, error) {
 	f.s3WriterCompleteCh = make(chan error, 1)
 	pr, pw := io.Pipe()
 
-	client, err := f.Location().FileSystem().(*FileSystem).Client()
+	client, err := f.location.fileSystem.Client()
 	if err != nil {
 		return nil, err
 	}
@@ -824,7 +824,7 @@ func (f *File) getS3Writer() (*io.PipeWriter, error) {
 
 func (f *File) getUploadPartitionSize() int64 {
 	partSize := defaultPartitionSize
-	opts := f.Location().FileSystem().(*FileSystem).options
+	opts := f.location.fileSystem.options
 	if opts.UploadPartitionSize != 0 {
 		partSize = opts.UploadPartitionSize
 	}
@@ -834,7 +834,7 @@ func (f *File) getUploadPartitionSize() int64 {
 
 func (f *File) getDownloadPartitionSize() int64 {
 	partSize := defaultPartitionSize
-	opts := f.Location().FileSystem().(*FileSystem).options
+	opts := f.location.fileSystem.options
 	if opts.DownloadPartitionSize != 0 {
 		partSize = opts.DownloadPartitionSize
 	}

--- a/backend/sftp/doc.go
+++ b/backend/sftp/doc.go
@@ -200,11 +200,11 @@ Example:
 		loc, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
 		file1, _ := loc.NewFile("file1.txt")
 		file2, _ := loc.NewFile("file2.txt")
-		file1.Touch()                               // "touches" file and starts disconnect timer (default: 10sec)
-		_, _ := loc.List()                          // stops timer, does location listing, resets timer to 10 seconds
-		file2.Touch()                               // stops timer, "touches" file2, resets timer to 10 seconds
-		time.Sleep(time.Duration(15) * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
-		_, _ := loc.List()                          // reconnects, does location listing, starts new disconnect timer
+		file1.Touch()                // "touches" file and starts disconnect timer (default: 10sec)
+		_, _ := loc.List()           // stops timer, does location listing, resets timer to 10 seconds
+		file2.Touch()                // stops timer, "touches" file2, resets timer to 10 seconds
+		time.Sleep(15 * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
+		_, _ := loc.List()           // reconnects, does location listing, starts new disconnect timer
 		return
 	}
 

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -179,11 +179,11 @@ should be the most desirable behavior.
     	loc, err := fs.NewLocation("myuser@server.com:22", "/some/path/")
     	file1, _ := loc.NewFile("file1.txt")
     	file2, _ := loc.NewFile("file2.txt")
-    	file1.Touch()                               // "touches" file and starts disconnect timer (default: 10sec)
-    	_, _ := loc.List()                          // stops timer, does location listing, resets timer to 10 seconds
-    	file2.Touch()                               // stops timer, "touches" file2, resets timer to 10 seconds
-    	time.Sleep(time.Duration(15) * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
-    	_, _ := loc.List()                          // reconnects, does location listing, starts new disconnect timer
+    	file1.Touch()                // "touches" file and starts disconnect timer (default: 10sec)
+    	_, _ := loc.List()           // stops timer, does location listing, resets timer to 10 seconds
+    	file2.Touch()                // stops timer, "touches" file2, resets timer to 10 seconds
+    	time.Sleep(15 * time.Second) // pause for 15 seconds, disconnects for server after 10 seconds
+    	_, _ := loc.List()           // reconnects, does location listing, starts new disconnect timer
     	return
     }
 


### PR DESCRIPTION
This project is full of unnecessary type assertions (aka casts) and type conversions. This PR removes as many of these as I could find, resulting in more concise and slightly more performant code.