### PR TITLE
sftp: Replace mockClosableClient with mockery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- SFTP backend: Replaced the hand-rolled `mockClosableClient` test type with mockery-generated mocks.
 
 ## [[v7.20.3](https://github.com/C2FO/vfs/releases/tag/v7.20.3)] - 2026-07-15
 ### Fixed


### PR DESCRIPTION
Remove `mockClosableClient` in the `sftp` backend, similar to #301. The mockery client is already being generated, best to just use that.