### PR TITLE
s3: Remove unnecessary mockClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use context from `testing.T` introduced in Go 1.24.
 - Define more sentinel errors for more ergonomic error checking.
 - Use typed expectations consistently for added type safety.
+- Remove unnecessary S3 `mockClient` type.
 ### Fixed
 - Use walrus assignment where possible.
 - Use the `any` keyword where possible.

--- a/backend/s3/fileSystem_test.go
+++ b/backend/s3/fileSystem_test.go
@@ -3,10 +3,9 @@ package s3
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/c2fo/vfs/v7/backend/s3/mocks"
 	"github.com/c2fo/vfs/v7/utils"
 )
 
@@ -14,21 +13,10 @@ type fileSystemTestSuite struct {
 	suite.Suite
 }
 
-var (
-	s3fs *FileSystem
-)
-
-type mockClient struct {
-	*s3.Client
-}
+var s3fs *FileSystem
 
 func (ts *fileSystemTestSuite) SetupTest() {
-	cfg, err := config.LoadDefaultConfig(ts.T().Context())
-	if err != nil {
-		panic(err)
-	}
-	client := mockClient{s3.NewFromConfig(cfg)}
-	s3fs = &FileSystem{client: client}
+	s3fs = &FileSystem{client: mocks.NewClient(ts.T())}
 }
 
 func (ts *fileSystemTestSuite) TestNewFileSystem() {


### PR DESCRIPTION
The `mockClient` type in the S3 backend has no effect since none of the file system tests actually make any client requests. This also means the S3 `LoadDefaultConfig` isn't required in `SetupTest`, which is nice because unit tests really shouldn't be reading AWS config from the local environment.