### PR TITLE
vfssimple: Remove unnecessary namedS3ClientMock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use context from `testing.T` introduced in Go 1.24.
 - Define more sentinel errors for more ergonomic error checking.
 - Use typed expectations consistently for added type safety.
+- Remove unnecessary vfssimple `namedS3ClientMock` type.
 ### Fixed
 - Use walrus assignment where possible.
 - Use the `any` keyword where possible.


### PR DESCRIPTION
There's no need for this custom mock wrapper since tests can simply compare the returned client pointers directly.