### PR TITLE
SECOPS-20799 - updating to use SHAs for github actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           git config --global url."https://c2fo-read-only:${{ secrets.GH_CI_READ }}@github.com/c2fo".insteadOf "https://github.com/c2fo"
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,13 +67,12 @@ jobs:
       # - name: Setup runtime (example)
       #   uses: actions/setup-example@v1
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: '1.24' # The Go version to download (if necessary) and use.
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        # using 4.30.7 below
-        uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5
+        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -101,7 +100,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        # using v4.30.7 below
-        uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5
+        uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/ensure_changelog.yml
+++ b/.github/workflows/ensure_changelog.yml
@@ -10,7 +10,7 @@ jobs:
     name: Did CHANGELOG.md change?
     steps:
       - name: checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: fetch
         run: git fetch
       - name: run changelog.sh

--- a/.github/workflows/go-test-coverage.yml
+++ b/.github/workflows/go-test-coverage.yml
@@ -9,16 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
 
       - name: Generate test coverage
         run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
 
       - name: Check test coverage
-        # using vladopajic/go-test-coverage@v2.17.0 below
-        uses: vladopajic/go-test-coverage@cc5012c2cfa84542e02b079141958a885861d326
+        uses: vladopajic/go-test-coverage@679e6807f68f2440a4c43d386442a1d0041838a9 # v2.18.3
         with:
           config: ./.testcoverage.yml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       modules: ${{ steps.modules.outputs.modules }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Find all modules
         id: modules
         run: |
@@ -35,19 +35,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24, 1.25]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [ 1.24, 1.25 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         module: ${{ fromJson(needs.get_modules.outputs.modules) }}
     runs-on: ${{ matrix.os }}
     name: Test ${{ matrix.module }} (Go ${{ matrix.go-version }}, ${{ matrix.os }})
     steps:
       - name: Install Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set TMPDIR for Windows
         if: matrix.os == 'windows-latest'
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,8 @@ jobs:
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: set-modules
         run: |
           # Find all directories containing go.mod files
@@ -43,13 +44,14 @@ jobs:
       matrix:
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
     steps:
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: '1.24'
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: golangci-lint
-        # the action below uses golangci/golangci-lint-action@v8.0.0
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all dependencies. Limit github.com/google/renameio/v2 to 2.0.1 because 2.0.2 requires go 1.25.
 - Fixed codeql security vulnerablity issue in mem backend: Incorrect conversion of a signed 64-bit integer from strconv.ParseInt
   to a lower bit size type int without an upper bound check.
+- Updating to use pin SHAs for github actions versions.
 ### Fixed
 - Avoid type assert and type convert where possible. (https://github.com/C2FO/vfs/pull/303)
 - Remove unnecessary S3 `mockClient` type. (https://github.com/C2FO/vfs/pull/305)


### PR DESCRIPTION
SECOPS-20799 - updating to use SHAs for github actions