### PR TITLE
fix gcs isSameAuth check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed GCS `CopyToFile` to compare source and target credentials before using native server-side copy; cross-account GCS copies now read with source auth and write with target auth.
 
 ## [v7.17.0]
 ### Fixed

--- a/backend/gs/file.go
+++ b/backend/gs/file.go
@@ -425,7 +425,7 @@ func (f *File) CopyToFile(file vfs.File) (err error) {
 			tf.opts = f.opts
 		}
 
-		if f.isSameAuth(&f.location.fileSystem.options) {
+		if f.isSameAuth(&tf.location.fileSystem.options) {
 			return f.copyWithinGCSToFile(tf)
 		}
 	}

--- a/backend/gs/file_test.go
+++ b/backend/gs/file_test.go
@@ -534,6 +534,81 @@ func (ts *fileTestSuite) TestMoveAndCopyBuffered() {
 	}
 }
 
+func (ts *fileTestSuite) TestIsSameAuth_SameCredentialFile() {
+	fs := NewFileSystem(WithOptions(Options{CredentialFile: "/path/to/creds.json"}))
+
+	src, err := fs.NewFile("bucket-a", "/source.txt")
+	ts.Require().NoError(err)
+	tgt, err := fs.NewFile("bucket-b", "/target.txt")
+	ts.Require().NoError(err)
+
+	ts.True(src.(*File).isSameAuth(&tgt.(*File).location.fileSystem.options))
+}
+
+func (ts *fileTestSuite) TestIsSameAuth_DifferentCredentialFile() {
+	sourceFs := NewFileSystem(WithOptions(Options{CredentialFile: "/path/to/source-creds.json"}))
+	targetFs := NewFileSystem(WithOptions(Options{CredentialFile: "/path/to/target-creds.json"}))
+
+	src, err := sourceFs.NewFile("bucket-a", "/source.txt")
+	ts.Require().NoError(err)
+	tgt, err := targetFs.NewFile("bucket-b", "/target.txt")
+	ts.Require().NoError(err)
+
+	ts.False(src.(*File).isSameAuth(&tgt.(*File).location.fileSystem.options))
+}
+
+func (ts *fileTestSuite) TestCopyToFileDifferentAuth() {
+	sourceName := "source.txt"
+	targetName := "target.txt"
+	sourceBucketName := "bucket-source"
+	targetBucketName := "bucket-target"
+	content := []byte("cross-account copy content")
+
+	server := fakestorage.NewServer(Objects{
+		fakestorage.Object{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName:  sourceBucketName,
+				Name:        sourceName,
+				ContentType: "text/plain",
+			},
+			Content: content,
+		},
+		fakestorage.Object{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName:  targetBucketName,
+				Name:        "place.holder",
+				ContentType: "text/plain",
+			},
+			Content: []byte{},
+		},
+	})
+	defer server.Stop()
+	client := server.Client()
+
+	sourceFs := NewFileSystem(
+		WithOptions(Options{CredentialFile: "/path/to/source-creds.json"}),
+		WithClient(client),
+	)
+	targetFs := NewFileSystem(
+		WithOptions(Options{CredentialFile: "/path/to/target-creds.json"}),
+		WithClient(client),
+	)
+
+	ctx := ts.T().Context()
+	sourceBucket := client.Bucket(sourceBucketName)
+	targetBucket := client.Bucket(targetBucketName)
+
+	sourceFile, err := sourceFs.NewFile(sourceBucketName, "/"+sourceName)
+	ts.Require().NoError(err)
+	targetFile, err := targetFs.NewFile(targetBucketName, "/"+targetName)
+	ts.Require().NoError(err)
+
+	ts.Require().NoError(sourceFile.CopyToFile(targetFile))
+	ts.True(objectExists(ctx, targetBucket, targetName))
+	ts.Equal(content, mustReadObject(ctx, targetBucket, targetName))
+	ts.True(objectExists(ctx, sourceBucket, sourceName))
+}
+
 func TestFile(t *testing.T) {
 	suite.Run(t, new(fileTestSuite))
 }

--- a/backend/gs/file_test.go
+++ b/backend/gs/file_test.go
@@ -564,7 +564,10 @@ func (ts *fileTestSuite) TestCopyToFileDifferentAuth() {
 	targetBucketName := "bucket-target"
 	content := []byte("cross-account copy content")
 
-	server := fakestorage.NewServer(Objects{
+	// Use separate fake GCS servers so a mistaken server-side copy cannot read the
+	// source object from the destination backend. Buffered copy reads via the source
+	// client and writes via the target client, which is the only path that can succeed.
+	sourceServer := fakestorage.NewServer(Objects{
 		fakestorage.Object{
 			ObjectAttrs: fakestorage.ObjectAttrs{
 				BucketName:  sourceBucketName,
@@ -573,6 +576,10 @@ func (ts *fileTestSuite) TestCopyToFileDifferentAuth() {
 			},
 			Content: content,
 		},
+	})
+	defer sourceServer.Stop()
+
+	targetServer := fakestorage.NewServer(Objects{
 		fakestorage.Object{
 			ObjectAttrs: fakestorage.ObjectAttrs{
 				BucketName:  targetBucketName,
@@ -582,21 +589,23 @@ func (ts *fileTestSuite) TestCopyToFileDifferentAuth() {
 			Content: []byte{},
 		},
 	})
-	defer server.Stop()
-	client := server.Client()
+	defer targetServer.Stop()
+
+	sourceClient := sourceServer.Client()
+	targetClient := targetServer.Client()
 
 	sourceFs := NewFileSystem(
 		WithOptions(Options{CredentialFile: "/path/to/source-creds.json"}),
-		WithClient(client),
+		WithClient(sourceClient),
 	)
 	targetFs := NewFileSystem(
 		WithOptions(Options{CredentialFile: "/path/to/target-creds.json"}),
-		WithClient(client),
+		WithClient(targetClient),
 	)
 
 	ctx := ts.T().Context()
-	sourceBucket := client.Bucket(sourceBucketName)
-	targetBucket := client.Bucket(targetBucketName)
+	sourceBucket := sourceClient.Bucket(sourceBucketName)
+	targetBucket := targetClient.Bucket(targetBucketName)
 
 	sourceFile, err := sourceFs.NewFile(sourceBucketName, "/"+sourceName)
 	ts.Require().NoError(err)


### PR DESCRIPTION
The gcs backend is currently checking whether a CopyToFile is happening between two locations with the same auth by comparing the source file to itself. Instead we should be comparing the source file to the target file.