### PR TITLE
fix(s3): include Region in isSameAuth to prevent cross-region CopyObject failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- S3 backend: `isSameAuth` now also compares `Region`, so same-credential copies across different regions fall back to client-side `TouchCopyBuffered` instead of a server-side `CopyObject` call that AWS rejects with `PermanentRedirect`.
 
 ## [[v7.20.1](https://github.com/C2FO/vfs/releases/tag/v7.20.1)] - 2026-06-22
 ### Documentation

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -621,9 +621,12 @@ func (f *File) isSameAuth(targetFile *File) (bool, types.ObjectCannedACL) {
 
 	// since access key and session token are mutually exclusive, one will be nil
 	// if both are the same, we're using the same credentials
+	// Region must also match since CopyObject is invoked via the source region's endpoint,
+	// which AWS rejects with PermanentRedirect for cross-region targets.
 	isSameAccount := (fileOptions.AccessKeyID == targetOptions.AccessKeyID) &&
 		(fileOptions.RoleARN == targetOptions.RoleARN) &&
-		(fileOptions.SessionToken == targetOptions.SessionToken)
+		(fileOptions.SessionToken == targetOptions.SessionToken) &&
+		(fileOptions.Region == targetOptions.Region)
 
 	return isSameAccount, ACL
 }

--- a/backend/s3/file.go
+++ b/backend/s3/file.go
@@ -619,10 +619,9 @@ func (f *File) isSameAuth(targetFile *File) (bool, types.ObjectCannedACL) {
 		ACL = targetOptions.ACL
 	}
 
-	// since access key and session token are mutually exclusive, one will be nil
-	// if both are the same, we're using the same credentials
-	// Region must also match since CopyObject is invoked via the source region's endpoint,
-	// which AWS rejects with PermanentRedirect for cross-region targets.
+	// same auth requires matching AccessKeyID, RoleARN, and SessionToken.
+	// Region must also match: CopyObject is invoked via the source region's endpoint,
+	// which AWS rejects with PermanentRedirect when the target is in a different region.
 	isSameAccount := (fileOptions.AccessKeyID == targetOptions.AccessKeyID) &&
 		(fileOptions.RoleARN == targetOptions.RoleARN) &&
 		(fileOptions.SessionToken == targetOptions.SessionToken) &&

--- a/backend/s3/file_test.go
+++ b/backend/s3/file_test.go
@@ -957,6 +957,18 @@ func (ts *fileTestSuite) TestIsSameAuth() {
 			targetOptions: Options{AccessKeyID: "key1", RoleARN: "arn:aws:iam::123456789:role/MyRole"},
 			expectedSame:  false,
 		},
+		{
+			name:          "same credentials, different regions - different auth",
+			sourceOptions: Options{AccessKeyID: "key1", Region: "us-west-2"},
+			targetOptions: Options{AccessKeyID: "key1", Region: "ap-south-1"},
+			expectedSame:  false,
+		},
+		{
+			name:          "same credentials, same region - same auth",
+			sourceOptions: Options{AccessKeyID: "key1", Region: "us-west-2"},
+			targetOptions: Options{AccessKeyID: "key1", Region: "us-west-2"},
+			expectedSame:  true,
+		},
 	}
 	for _, tt := range tests { //nolint:gocritic //rangeValCopy
 		ts.Run(tt.name, func() {


### PR DESCRIPTION
## Summary
- `isSameAuth` in `backend/s3/file.go` only compared `AccessKeyID`, `RoleARN`, and `SessionToken`, so same-credential copies between buckets in different AWS regions were treated as same-auth and routed through the server-side `CopyObject` API.
- AWS rejects that call with `PermanentRedirect` (HTTP 301) when source and target regions differ, since `CopyObject` is invoked via the source region's endpoint.
- `Region` is now part of the `isSameAuth` comparison, so same-credential, different-region copies correctly fall back to the client-side `TouchCopyBuffered` path, which uses each filesystem's own regional client.

## Test plan
- [x] Added unit tests covering same-credentials/different-region (expect `false`) and same-credentials/same-region (expect `true`) cases in `TestIsSameAuth`
- [x] `go test ./backend/s3/...` passes
- [x] `golangci-lint run ./backend/s3/...` passes clean
- [x] Updated `CHANGELOG.md` under `[Unreleased]` per repo conventions
