### PR TITLE
fix(vfsevents): remove sleep-based races in vfsevents watcher tests

### DIFF
--- a/contrib/vfsevents/CHANGELOG.md
+++ b/contrib/vfsevents/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `TestGCSWatcherTestSuite/TestEnhancedMetadata`, `TestGCSWatcherTestSuite/TestOverwriteEventSuppression`, and `TestGCSWatcherTestSuite/TestRetryBackoffTiming`: replaced fixed `time.Sleep` waits with synchronization on the `receiveWithRetry` goroutine's completion (via an error channel), so these tests no longer race with the goroutine's writes to shared test state. See [#340](https://github.com/C2FO/vfs/issues/340).
 
 ## [[contrib/vfsevents/v1.2.1](https://github.com/C2FO/vfs/releases/tag/contrib%2Fvfsevents%2Fv1.2.1)] - 2026-07-16
 ### Fixed

--- a/contrib/vfsevents/CHANGELOG.md
+++ b/contrib/vfsevents/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - `TestGCSWatcherTestSuite/TestEnhancedMetadata`, `TestGCSWatcherTestSuite/TestOverwriteEventSuppression`, and `TestGCSWatcherTestSuite/TestRetryBackoffTiming`: replaced fixed `time.Sleep` waits with synchronization on the `receiveWithRetry` goroutine's completion (via an error channel), so these tests no longer race with the goroutine's writes to shared test state. See [#340](https://github.com/C2FO/vfs/issues/340).
+- `TestS3WatcherTestSuite/TestEnhancedMetadata`: fixed a CI-observed flake where the test could finish (and its mock-expectation teardown could run) before the background `pollOnce` goroutine's `DeleteMessage` call happened, since the test only synchronized on the event handler firing rather than on `pollOnce` fully returning. Now uses the same completion-based synchronization as `TestNonVersionedBucketMetadata` (extracted into a shared `waitForPoll` helper), which also proactively avoids the un-stopped `time.After` timer issue raised in review of this PR.
 
 ## [[contrib/vfsevents/v1.2.1](https://github.com/C2FO/vfs/releases/tag/contrib%2Fvfsevents%2Fv1.2.1)] - 2026-07-16
 ### Fixed

--- a/contrib/vfsevents/watchers/gcsevents/gcsevents_test.go
+++ b/contrib/vfsevents/watchers/gcsevents/gcsevents_test.go
@@ -31,6 +31,42 @@ func (s *GCSWatcherTestSuite) SetupTest() {
 	s.watcher, _ = NewGCSWatcher("my-project-id", "my-subscription", WithPubSubClient(s.pubsubClient))
 }
 
+// waitForReceive waits for a receiveWithRetry goroutine (running in the
+// background and signaling its return value on done) to complete, instead of
+// sleeping a fixed duration. This avoids racing with the goroutine's writes
+// to test-local state (e.g. a captured event).
+//
+// If the goroutine doesn't finish within timeout, cancel is invoked
+// immediately (rather than relying solely on a deferred cancel, which only
+// fires once the calling test function returns) and a short, bounded grace
+// period is given for the goroutine to exit before failing the test. This
+// prevents the goroutine from continuing to run - and potentially hitting
+// the mock - after the subtest has already failed.
+//
+// ok is false if the wait timed out (the test has already been failed via
+// s.Fail); callers should return immediately in that case.
+func (s *GCSWatcherTestSuite) waitForReceive(
+	done <-chan error, cancel context.CancelFunc, timeout time.Duration, failMsg string,
+) (err error, ok bool) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err, true
+	case <-timer.C:
+		cancel()
+		graceTimer := time.NewTimer(500 * time.Millisecond)
+		defer graceTimer.Stop()
+		select {
+		case <-done:
+		case <-graceTimer.C:
+		}
+		s.Fail(failMsg)
+		return nil, false
+	}
+}
+
 func (s *GCSWatcherTestSuite) TestNewGCSWatcher() {
 	tests := []struct {
 		name           string
@@ -529,17 +565,22 @@ func (s *GCSWatcherTestSuite) TestRetryBackoffTiming() {
 		Return(nil).
 		Once()
 
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	config := &vfsevents.StartConfig{}
 	status := &vfsevents.WatcherStatus{}
 
+	done := make(chan error, 1)
 	go func() {
-		_ = s.watcher.receiveWithRetry(ctx, handler, errHandler, status, config)
+		done <- s.watcher.receiveWithRetry(ctx, handler, errHandler, status, config)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	err, ok := s.waitForReceive(done, cancel, 2*time.Second, "Timeout waiting for GCS event to be processed")
+	if !ok {
+		return
+	}
+	s.Require().NoError(err, "receiveWithRetry should process the message without error")
 
 	// Verify event was processed
 	s.NotEmpty(receivedEvents, "Should process events without error")
@@ -706,17 +747,22 @@ func (s *GCSWatcherTestSuite) TestEnhancedMetadata() {
 		Return(nil).
 		Once()
 
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	config := &vfsevents.StartConfig{}
 	status := &vfsevents.WatcherStatus{}
 
+	done := make(chan error, 1)
 	go func() {
-		_ = s.watcher.receiveWithRetry(ctx, handler, errHandler, status, config)
+		done <- s.watcher.receiveWithRetry(ctx, handler, errHandler, status, config)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	err, ok := s.waitForReceive(done, cancel, 2*time.Second, "Timeout waiting for GCS event to be processed")
+	if !ok {
+		return
+	}
+	s.Require().NoError(err, "receiveWithRetry should process the message without error")
 
 	s.Require().NotNil(receivedEvent)
 	s.Equal(vfsevents.EventModified, receivedEvent.Type) // Should be Modified due to overwroteGeneration
@@ -786,17 +832,22 @@ func (s *GCSWatcherTestSuite) TestOverwriteEventSuppression() {
 		Return(nil).
 		Once()
 
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	config := &vfsevents.StartConfig{}
 	status := &vfsevents.WatcherStatus{}
 
+	done := make(chan error, 1)
 	go func() {
-		_ = s.watcher.receiveWithRetry(ctx, handler, errHandler, status, config)
+		done <- s.watcher.receiveWithRetry(ctx, handler, errHandler, status, config)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	err, ok := s.waitForReceive(done, cancel, 2*time.Second, "Timeout waiting for GCS events to be processed")
+	if !ok {
+		return
+	}
+	s.Require().NoError(err, "receiveWithRetry should process the messages without error")
 
 	// Verify only one event was generated (the OBJECT_FINALIZE -> EventModified)
 	s.Require().Len(receivedEvents, 1, "Should only receive one event for overwrite operation")

--- a/contrib/vfsevents/watchers/s3events/s3events_test.go
+++ b/contrib/vfsevents/watchers/s3events/s3events_test.go
@@ -33,6 +33,44 @@ func (s *S3WatcherTestSuite) SetupTest() {
 	s.watcher, _ = NewS3Watcher("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue", WithSqsClient(s.sqsClient))
 }
 
+// waitForPoll waits for a pollOnce goroutine (running in the background and
+// signaling its return value on done) to complete, instead of sleeping a
+// fixed duration or only synchronizing on the handler firing. This avoids
+// racing with the goroutine's writes to test-local state and guarantees any
+// mock calls made after the handler runs (e.g. DeleteMessage) have already
+// happened before this subtest's assertions and mock-expectation teardown.
+//
+// If the goroutine doesn't finish within timeout, cancel is invoked
+// immediately (rather than relying solely on a deferred cancel, which only
+// fires once the calling test function returns) and a short, bounded grace
+// period is given for the goroutine to exit before failing the test. This
+// prevents the goroutine from continuing to run - and potentially hitting
+// the mock - after the subtest has already failed.
+//
+// ok is false if the wait timed out (the test has already been failed via
+// s.Fail); callers should return immediately in that case.
+func (s *S3WatcherTestSuite) waitForPoll(
+	done <-chan error, cancel context.CancelFunc, timeout time.Duration, failMsg string,
+) (err error, ok bool) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err, true
+	case <-timer.C:
+		cancel()
+		graceTimer := time.NewTimer(500 * time.Millisecond)
+		defer graceTimer.Stop()
+		select {
+		case <-done:
+		case <-graceTimer.C:
+		}
+		s.Fail(failMsg)
+		return nil, false
+	}
+}
+
 func (s *S3WatcherTestSuite) TestNewS3Watcher() {
 	tests := []struct {
 		name     string
@@ -897,10 +935,8 @@ func (s *S3WatcherTestSuite) TestGetOperationType() {
 func (s *S3WatcherTestSuite) TestEnhancedMetadata() {
 	// Test that enhanced metadata is properly captured and included in events
 	var receivedEvent vfsevents.Event
-	eventReceived := make(chan bool, 1)
 	handler := func(event vfsevents.Event) {
 		receivedEvent = event
-		eventReceived <- true
 	}
 	// Create a comprehensive S3 event with all metadata fields
 	s3Event := S3Event{
@@ -948,18 +984,16 @@ func (s *S3WatcherTestSuite) TestEnhancedMetadata() {
 	status := &vfsevents.WatcherStatus{}
 
 	// Start pollOnce in goroutine
+	done := make(chan error, 1)
 	go func() {
-		_ = s.watcher.pollOnce(ctx, handler, status, config)
+		done <- s.watcher.pollOnce(ctx, handler, status, config)
 	}()
 
-	// Wait for event to be received with timeout
-	select {
-	case <-eventReceived:
-		// Event received successfully
-	case <-time.After(2 * time.Second):
-		s.Fail("Timeout waiting for S3 event to be processed")
+	err, ok := s.waitForPoll(done, cancel, 2*time.Second, "Timeout waiting for S3 event to be processed")
+	if !ok {
 		return
 	}
+	s.Require().NoError(err, "pollOnce should process the message without error")
 
 	// Verify the event was processed and contains enhanced metadata
 	s.Equal(vfsevents.EventModified, receivedEvent.Type, "Copy operation should be mapped to EventModified")
@@ -1030,33 +1064,16 @@ func (s *S3WatcherTestSuite) TestNonVersionedBucketMetadata() {
 	config := &vfsevents.StartConfig{}
 	status := &vfsevents.WatcherStatus{}
 
-	// Wait for pollOnce to fully return (handler call + DeleteMessage) instead
-	// of sleeping or only waiting for the handler to fire, so the goroutine's
-	// write to receivedEvent is synchronized with this goroutine's read below
-	// and the DeleteMessage expectation is guaranteed to be satisfied before
-	// this subtest (and its mock assertions) complete.
 	done := make(chan error, 1)
 	go func() {
 		done <- s.watcher.pollOnce(ctx, handler, status, config)
 	}()
 
-	select {
-	case err := <-done:
-		s.Require().NoError(err, "pollOnce should process the message without error")
-	case <-time.After(2 * time.Second):
-		// Cancel immediately (rather than relying on the deferred cancel, which
-		// only fires once this function returns) and give the goroutine a
-		// short, bounded window to exit before we return. Otherwise it could
-		// keep running and hit the mock after this subtest has already failed,
-		// triggering a confusing secondary unexpected-call panic.
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(500 * time.Millisecond):
-		}
-		s.Fail("Timeout waiting for S3 event to be processed")
+	err, ok := s.waitForPoll(done, cancel, 2*time.Second, "Timeout waiting for S3 event to be processed")
+	if !ok {
 		return
 	}
+	s.Require().NoError(err, "pollOnce should process the message without error")
 
 	// Verify the event was processed
 	s.Equal(vfsevents.EventCreated, receivedEvent.Type, "Put operation should be mapped to EventCreated")


### PR DESCRIPTION
## Summary

Fixes #340. Also folds in the fix for a CI-observed flake in `s3events` (was briefly its own PR, #342, now consolidated here since it's the same root-cause pattern).

### gcsevents (fixes #340)

Same root cause as #339: `TestEnhancedMetadata`, `TestOverwriteEventSuppression`, and `TestRetryBackoffTiming` in `contrib/vfsevents/watchers/gcsevents` each start `receiveWithRetry` in a goroutine and then read test-local state (`receivedEvent`/`receivedEvents`) after a fixed `time.Sleep(50ms)`, racing with the goroutine's write. Confirmed with `go test -race -run TestGCSWatcherTestSuite ./watchers/gcsevents/...` on `main` — all three fail reliably.

Since `RetryConfig.Enabled` defaults to `false` (zero value), `receiveWithRetry` short-circuits to a single `receive()` call and returns, matching each test's `.Once()` mock expectations.

### s3events (CI flake found after merging #339)

CI on ubuntu + go1.26 hit:

```
FAIL: DeleteMessage(string,string)
FAIL: 1 out of 2 expectation(s) were met.
```

in `TestEnhancedMetadata`. That test only synchronized on the event handler firing (via an `eventReceived` channel), not on `pollOnce`'s own completion — a residual race flagged (but not fixed at the time) during review of #339's fix for the sibling `TestNonVersionedBucketMetadata` test. On CI's scheduler, the subtest could finish (and trigger its mock-expectation teardown) before the background `pollOnce` goroutine's `DeleteMessage` call happened.

## Changes
- All three `gcsevents` tests now wait on `receiveWithRetry`'s own completion via an error channel (matching the hardened pattern from #339, including its review feedback) instead of a fixed sleep, and assert the call returns without error. Extracted into a shared `waitForReceive` suite helper.
- `s3events/TestEnhancedMetadata` now uses the same completion-based synchronization as `TestNonVersionedBucketMetadata`, extracted into a shared `waitForPoll` suite helper.
- Both helpers use `time.NewTimer` + `defer timer.Stop()` (not `time.After`), per review feedback on this PR, to avoid leaving timers pending when the happy path wins the select.
- On the timeout path (either package), the context is canceled immediately (not just via the deferred cancel) and the goroutine gets a short, bounded grace window before the subtest fails — avoiding a lingering goroutine that could still touch the mock after the subtest has already failed.
- Updated `contrib/vfsevents/CHANGELOG.md` under `[Unreleased]`.

## Test plan
- `go test -race -run TestGCSWatcherTestSuite -count=200 ./contrib/vfsevents/watchers/gcsevents/...` — clean (previously failed on all three named subtests).
- `go test -race -run TestS3WatcherTestSuite -count=300 ./contrib/vfsevents/watchers/s3events/...` — clean.
- `go test -run TestS3WatcherTestSuite -count=1000 ./contrib/vfsevents/watchers/s3events/...` (no `-race`, to stress scheduling/timing rather than just data races) — clean.
- `go test -race ./contrib/vfsevents/...` — clean.
- `go build ./... && go vet ./...` for `contrib/vfsevents` — clean.
- `golangci-lint run ./watchers/gcsevents/... ./watchers/s3events/...` — only pre-existing, unrelated `nolintlint` findings (not touched by this PR).

Made with [Cursor](https://cursor.com)