### PR TITLE
fix(vfsevents): fix CI-observed flake in s3events TestEnhancedMetadata

### DIFF
--- a/contrib/vfsevents/CHANGELOG.md
+++ b/contrib/vfsevents/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `TestS3WatcherTestSuite/TestEnhancedMetadata`: fixed a CI-observed flake where the test could finish (and its mock-expectation teardown could run) before the background `pollOnce` goroutine's `DeleteMessage` call happened, since the test only synchronized on the event handler firing rather than on `pollOnce` fully returning. Now uses the same completion-based synchronization as `TestNonVersionedBucketMetadata` (extracted into a shared `waitForPoll` helper), which also proactively avoids the un-stopped `time.After` timer issue raised in review of [#341](https://github.com/C2FO/vfs/pull/341).
 
 ## [[contrib/vfsevents/v1.2.1](https://github.com/C2FO/vfs/releases/tag/contrib%2Fvfsevents%2Fv1.2.1)] - 2026-07-16
 ### Fixed

--- a/contrib/vfsevents/watchers/s3events/s3events_test.go
+++ b/contrib/vfsevents/watchers/s3events/s3events_test.go
@@ -33,6 +33,44 @@ func (s *S3WatcherTestSuite) SetupTest() {
 	s.watcher, _ = NewS3Watcher("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue", WithSqsClient(s.sqsClient))
 }
 
+// waitForPoll waits for a pollOnce goroutine (running in the background and
+// signaling its return value on done) to complete, instead of sleeping a
+// fixed duration or only synchronizing on the handler firing. This avoids
+// racing with the goroutine's writes to test-local state and guarantees any
+// mock calls made after the handler runs (e.g. DeleteMessage) have already
+// happened before this subtest's assertions and mock-expectation teardown.
+//
+// If the goroutine doesn't finish within timeout, cancel is invoked
+// immediately (rather than relying solely on a deferred cancel, which only
+// fires once the calling test function returns) and a short, bounded grace
+// period is given for the goroutine to exit before failing the test. This
+// prevents the goroutine from continuing to run - and potentially hitting
+// the mock - after the subtest has already failed.
+//
+// ok is false if the wait timed out (the test has already been failed via
+// s.Fail); callers should return immediately in that case.
+func (s *S3WatcherTestSuite) waitForPoll(
+	done <-chan error, cancel context.CancelFunc, timeout time.Duration, failMsg string,
+) (err error, ok bool) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err, true
+	case <-timer.C:
+		cancel()
+		graceTimer := time.NewTimer(500 * time.Millisecond)
+		defer graceTimer.Stop()
+		select {
+		case <-done:
+		case <-graceTimer.C:
+		}
+		s.Fail(failMsg)
+		return nil, false
+	}
+}
+
 func (s *S3WatcherTestSuite) TestNewS3Watcher() {
 	tests := []struct {
 		name     string
@@ -897,10 +935,8 @@ func (s *S3WatcherTestSuite) TestGetOperationType() {
 func (s *S3WatcherTestSuite) TestEnhancedMetadata() {
 	// Test that enhanced metadata is properly captured and included in events
 	var receivedEvent vfsevents.Event
-	eventReceived := make(chan bool, 1)
 	handler := func(event vfsevents.Event) {
 		receivedEvent = event
-		eventReceived <- true
 	}
 	// Create a comprehensive S3 event with all metadata fields
 	s3Event := S3Event{
@@ -948,18 +984,16 @@ func (s *S3WatcherTestSuite) TestEnhancedMetadata() {
 	status := &vfsevents.WatcherStatus{}
 
 	// Start pollOnce in goroutine
+	done := make(chan error, 1)
 	go func() {
-		_ = s.watcher.pollOnce(ctx, handler, status, config)
+		done <- s.watcher.pollOnce(ctx, handler, status, config)
 	}()
 
-	// Wait for event to be received with timeout
-	select {
-	case <-eventReceived:
-		// Event received successfully
-	case <-time.After(2 * time.Second):
-		s.Fail("Timeout waiting for S3 event to be processed")
+	err, ok := s.waitForPoll(done, cancel, 2*time.Second, "Timeout waiting for S3 event to be processed")
+	if !ok {
 		return
 	}
+	s.Require().NoError(err, "pollOnce should process the message without error")
 
 	// Verify the event was processed and contains enhanced metadata
 	s.Equal(vfsevents.EventModified, receivedEvent.Type, "Copy operation should be mapped to EventModified")
@@ -1030,33 +1064,16 @@ func (s *S3WatcherTestSuite) TestNonVersionedBucketMetadata() {
 	config := &vfsevents.StartConfig{}
 	status := &vfsevents.WatcherStatus{}
 
-	// Wait for pollOnce to fully return (handler call + DeleteMessage) instead
-	// of sleeping or only waiting for the handler to fire, so the goroutine's
-	// write to receivedEvent is synchronized with this goroutine's read below
-	// and the DeleteMessage expectation is guaranteed to be satisfied before
-	// this subtest (and its mock assertions) complete.
 	done := make(chan error, 1)
 	go func() {
 		done <- s.watcher.pollOnce(ctx, handler, status, config)
 	}()
 
-	select {
-	case err := <-done:
-		s.Require().NoError(err, "pollOnce should process the message without error")
-	case <-time.After(2 * time.Second):
-		// Cancel immediately (rather than relying on the deferred cancel, which
-		// only fires once this function returns) and give the goroutine a
-		// short, bounded window to exit before we return. Otherwise it could
-		// keep running and hit the mock after this subtest has already failed,
-		// triggering a confusing secondary unexpected-call panic.
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(500 * time.Millisecond):
-		}
-		s.Fail("Timeout waiting for S3 event to be processed")
+	err, ok := s.waitForPoll(done, cancel, 2*time.Second, "Timeout waiting for S3 event to be processed")
+	if !ok {
 		return
 	}
+	s.Require().NoError(err, "pollOnce should process the message without error")
 
 	// Verify the event was processed
 	s.Equal(vfsevents.EventCreated, receivedEvent.Type, "Put operation should be mapped to EventCreated")


### PR DESCRIPTION
## Summary

Fixes a CI failure observed on ubuntu + go1.26 after #339 merged:

```
--- FAIL: TestS3WatcherTestSuite/TestEnhancedMetadata
    SqsClient.go:23: FAIL: DeleteMessage(string,string)
    SqsClient.go:23: FAIL: 1 out of 2 expectation(s) were met.
        The code you are testing needs to make 1 more call(s).
```

## Root cause

`TestEnhancedMetadata` only synchronized on the event handler firing (via an `eventReceived` channel), not on `pollOnce`'s own completion. This meant the subtest could reach its assertions and finish (triggering mock-expectation teardown) before the background `pollOnce` goroutine made its `DeleteMessage` call — a timing gap that's tight enough to usually pass locally but wide enough to occasionally lose the race on CI runners.

This is exactly the residual race risk flagged (but intentionally not fixed at the time, since it wasn't the primary target) during review of #339's fix for the sibling `TestNonVersionedBucketMetadata` test.

## Fix
- `TestEnhancedMetadata` now uses the same completion-based synchronization as `TestNonVersionedBucketMetadata` — waits for `pollOnce` to fully return via an error channel, rather than only waiting for the handler to fire.
- Extracted the shared wait/cancel/grace-period logic (previously only in `TestNonVersionedBucketMetadata`) into a `waitForPoll` suite helper, now used by both tests, mirroring the equivalent `waitForReceive` helper added to `gcsevents_test.go` in #341.
- Uses `time.NewTimer` + `defer timer.Stop()` throughout (rather than `time.After`), proactively addressing the un-stopped-timer issue raised in review of #341.
- Updated `contrib/vfsevents/CHANGELOG.md`.

## Test plan
- `go test -race -run TestS3WatcherTestSuite -count=300 ./contrib/vfsevents/watchers/s3events/...` — clean.
- `go test -run TestS3WatcherTestSuite -count=1000 ./contrib/vfsevents/watchers/s3events/...` (no `-race`, to stress scheduling/timing rather than just data races) — clean.
- `go build ./... && go vet ./...` for `contrib/vfsevents` — clean.
- `golangci-lint run ./watchers/s3events/...` — only a pre-existing, unrelated `nolintlint` finding in `s3events.go` (not touched by this PR).

Made with [Cursor](https://cursor.com)