### PR TITLE
test(conformance): add ConformanceOptions to RunIOTests and fix EOF handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `backend/testsuite`: `RunIOTests` now accepts optional `ConformanceOptions`, allowing backends to skip IO sequences they cannot support. `SkipFTPSpecificTests` skips the "Write, Seek, Write" (partial write) cases, which FTP cannot perform.
+
+### Fixed
+- `backend/testsuite`: `ExecuteSequence` now treats `io.EOF` returned from a fixed-size read as a valid end-of-file condition and continues the sequence, rather than aborting it. Some backends return `io.EOF` alongside the final bytes of a read.
 
 ## [[v7.20.7](https://github.com/C2FO/vfs/releases/tag/v7.20.7)] - 2026-07-23
 ### Fixed

--- a/backend/ftp/conformance_test.go
+++ b/backend/ftp/conformance_test.go
@@ -62,5 +62,9 @@ func TestIOConformance(t *testing.T) {
 		t.Fatalf("failed to create FTP test location: %v", err)
 	}
 
-	testsuite.RunIOTests(t, location)
+	opts := testsuite.ConformanceOptions{
+		SkipFTPSpecificTests: true,
+	}
+
+	testsuite.RunIOTests(t, location, opts)
 }

--- a/backend/testsuite/io_conformance.go
+++ b/backend/testsuite/io_conformance.go
@@ -30,6 +30,21 @@ type IOTestCase struct {
 	FileAlreadyExists bool
 	ExpectFailure     bool
 	ExpectedResults   string
+
+	// RequiresSeekWithinWrite marks sequences that seek backward within an
+	// open write stream and then write again (i.e. "Write, Seek, Write").
+	// Stream-only backends such as FTP cannot rewind an in-progress upload,
+	// so these cases are skipped when ConformanceOptions.SkipFTPSpecificTests
+	// is set.
+	//
+	// NOTE (PR C): the exact set of IO sequences FTP cannot support is
+	// currently inferred from prior work (#294) and only validated against a
+	// real FTP server under the vfsintegration build tag. When the
+	// testcontainers module runs these against vsftpd, confirm whether other
+	// partial-write sequences (e.g. "Seek, Write" / "Read, Write") also need
+	// this flag; if so, set it on those cases here rather than widening the
+	// skip predicate.
+	RequiresSeekWithinWrite bool
 }
 
 // DefaultIOTestCases returns the standard set of IO test cases
@@ -78,18 +93,20 @@ func DefaultIOTestCases() []IOTestCase {
 
 		// Write, Seek, Write, Close
 		{
-			Description:       "Write, Seek, Write, Close, file does not exist",
-			Sequence:          "W(this and that);S(0,0);W(that);C()",
-			FileAlreadyExists: false,
-			ExpectFailure:     false,
-			ExpectedResults:   "that and that",
+			Description:             "Write, Seek, Write, Close, file does not exist",
+			Sequence:                "W(this and that);S(0,0);W(that);C()",
+			FileAlreadyExists:       false,
+			ExpectFailure:           false,
+			ExpectedResults:         "that and that",
+			RequiresSeekWithinWrite: true,
 		},
 		{
-			Description:       "Write, Seek, Write, Close, file exists",
-			Sequence:          "W(this and that);S(0,0);W(that);C()",
-			FileAlreadyExists: true,
-			ExpectFailure:     false,
-			ExpectedResults:   "that and that",
+			Description:             "Write, Seek, Write, Close, file exists",
+			Sequence:                "W(this and that);S(0,0);W(that);C()",
+			FileAlreadyExists:       true,
+			ExpectFailure:           false,
+			ExpectedResults:         "that and that",
+			RequiresSeekWithinWrite: true,
 		},
 
 		// Seek
@@ -202,10 +219,10 @@ func runIOTestsWithCases(t *testing.T, testPath string, location vfs.Location, t
 			testFileName := "testfile.txt"
 
 			// FTP streams writes directly to the server and cannot rewind an
-			// in-progress write, so "Write, Seek, Write" sequences (partial
-			// writes) are unsupported on that backend.
-			if opts.SkipFTPSpecificTests && strings.HasPrefix(tc.Description, "Write, Seek, Write") {
-				t.Skip("partial writes (Write, Seek, Write) are not supported by this backend")
+			// in-progress write, so "Write, Seek, Write" sequences are
+			// unsupported on that backend.
+			if opts.SkipFTPSpecificTests && tc.RequiresSeekWithinWrite {
+				t.Skip("seek-within-write sequences are not supported by this backend")
 			}
 
 			func() {

--- a/backend/testsuite/io_conformance.go
+++ b/backend/testsuite/io_conformance.go
@@ -312,14 +312,16 @@ SEQ:
 					t.Fatalf("invalid bytesize: %s", commandArgs[0])
 				}
 				b := make([]byte, bytesize)
-				_, commandErr = file.Read(b)
+				var n int
+				n, commandErr = file.Read(b)
 				if commandErr != nil {
 					// Reading up to (and not past) the end of the file is a
 					// valid, non-fatal condition: some backends return io.EOF
-					// alongside the final bytes of a read. Treat that as a
-					// successful read and continue the sequence rather than
-					// aborting it.
-					if errors.Is(commandErr, io.EOF) {
+					// alongside the final bytes of a fully-satisfied read.
+					// Only forgive io.EOF in that exact case; a short read
+					// (n < bytesize) paired with io.EOF is a genuine failure
+					// and must not be masked.
+					if errors.Is(commandErr, io.EOF) && uint64(n) == bytesize {
 						commandErr = nil
 						continue
 					}

--- a/backend/testsuite/io_conformance.go
+++ b/backend/testsuite/io_conformance.go
@@ -1,6 +1,7 @@
 package testsuite
 
 import (
+	"errors"
 	"io"
 	"regexp"
 	"strconv"
@@ -180,19 +181,32 @@ func DefaultIOTestCases() []IOTestCase {
 	}
 }
 
-// RunIOTests runs IO conformance tests against the provided location
-func RunIOTests(t *testing.T, location vfs.Location) {
+// RunIOTests runs IO conformance tests against the provided location.
+// Optional ConformanceOptions allow backends to skip IO sequences they cannot
+// support (e.g. FTP, which cannot perform partial writes).
+func RunIOTests(t *testing.T, location vfs.Location, opts ...ConformanceOptions) {
 	t.Helper()
-	runIOTestsWithCases(t, location.URI(), location, DefaultIOTestCases())
+	opt := ConformanceOptions{}
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	runIOTestsWithCases(t, location.URI(), location, DefaultIOTestCases(), opt)
 }
 
-func runIOTestsWithCases(t *testing.T, testPath string, location vfs.Location, testCases []IOTestCase) {
+func runIOTestsWithCases(t *testing.T, testPath string, location vfs.Location, testCases []IOTestCase, opts ConformanceOptions) {
 	t.Helper()
 	defer teardownTestLocation(t, testPath, location)
 
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {
 			testFileName := "testfile.txt"
+
+			// FTP streams writes directly to the server and cannot rewind an
+			// in-progress write, so "Write, Seek, Write" sequences (partial
+			// writes) are unsupported on that backend.
+			if opts.SkipFTPSpecificTests && strings.HasPrefix(tc.Description, "Write, Seek, Write") {
+				t.Skip("partial writes (Write, Seek, Write) are not supported by this backend")
+			}
 
 			func() {
 				file, err := setupTestFile(tc.FileAlreadyExists, location, testFileName)
@@ -283,6 +297,15 @@ SEQ:
 				b := make([]byte, bytesize)
 				_, commandErr = file.Read(b)
 				if commandErr != nil {
+					// Reading up to (and not past) the end of the file is a
+					// valid, non-fatal condition: some backends return io.EOF
+					// alongside the final bytes of a read. Treat that as a
+					// successful read and continue the sequence rather than
+					// aborting it.
+					if errors.Is(commandErr, io.EOF) {
+						commandErr = nil
+						continue
+					}
 					break SEQ
 				}
 			}

--- a/backend/testsuite/io_conformance_test.go
+++ b/backend/testsuite/io_conformance_test.go
@@ -1,0 +1,97 @@
+package testsuite
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/c2fo/vfs/v7"
+	"github.com/c2fo/vfs/v7/backend/mem"
+)
+
+// newMemIOLocation returns an isolated in-memory location for IO testing.
+func newMemIOLocation(t *testing.T) vfs.Location {
+	t.Helper()
+	loc, err := mem.NewFileSystem().NewLocation("testvolume", "/vfs-io-test/")
+	require.NoError(t, err)
+	return loc
+}
+
+// TestRunIOTests_Mem exercises the full IO conformance suite against the
+// in-memory backend, which supports every sequence (including partial writes).
+// This gives the conformance runner, ExecuteSequence, and the helpers real
+// coverage in the default (non-vfsintegration) test run.
+func TestRunIOTests_Mem(t *testing.T) {
+	RunIOTests(t, newMemIOLocation(t))
+}
+
+// TestRunIOTests_MemSkipFTP runs the suite with SkipFTPSpecificTests set,
+// exercising the skip path. The in-memory backend supports the skipped
+// sequences, so the run must still pass with those cases skipped.
+func TestRunIOTests_MemSkipFTP(t *testing.T) {
+	RunIOTests(t, newMemIOLocation(t), ConformanceOptions{SkipFTPSpecificTests: true})
+}
+
+// TestDefaultIOTestCases_SeekWithinWriteFlag locks the mapping between IO test
+// cases and the RequiresSeekWithinWrite flag so a renamed description or a new
+// case can't silently change which sequences FTP-style backends skip.
+func TestDefaultIOTestCases_SeekWithinWriteFlag(t *testing.T) {
+	seekWithinWrite := make(map[string]bool)
+	for _, tc := range DefaultIOTestCases() {
+		seekWithinWrite[tc.Description] = tc.RequiresSeekWithinWrite
+	}
+
+	want := map[string]bool{
+		"Write, Seek, Write, Close, file does not exist": true,
+		"Write, Seek, Write, Close, file exists":         true,
+	}
+
+	trueCount := 0
+	for desc, flagged := range seekWithinWrite {
+		if flagged {
+			trueCount++
+			require.Truef(t, want[desc], "unexpected case flagged RequiresSeekWithinWrite: %q", desc)
+		}
+	}
+	require.Equalf(t, len(want), trueCount,
+		"expected exactly %d cases flagged RequiresSeekWithinWrite, got %d", len(want), trueCount)
+}
+
+// eofInjectingFile wraps a vfs.File and returns io.EOF alongside the final
+// bytes of a fully-satisfied read, simulating backends (e.g. s3) that signal
+// EOF on the read that reaches the end of the file rather than on the next one.
+type eofInjectingFile struct {
+	vfs.File
+}
+
+func (f *eofInjectingFile) Read(p []byte) (int, error) {
+	n, err := f.File.Read(p)
+	if err == nil && n > 0 && n == len(p) {
+		return n, io.EOF
+	}
+	return n, err
+}
+
+// TestExecuteSequence_EOFOnFullRead verifies that a fixed-size read returning
+// io.EOF together with data is treated as a successful read: the sequence must
+// continue (so the trailing Close runs) and report no error.
+func TestExecuteSequence_EOFOnFullRead(t *testing.T) {
+	loc := newMemIOLocation(t)
+
+	seed, err := loc.NewFile("eoftest.txt")
+	require.NoError(t, err)
+	_, err = seed.Write([]byte("some text"))
+	require.NoError(t, err)
+	require.NoError(t, seed.Close())
+
+	readFile, err := loc.NewFile("eoftest.txt")
+	require.NoError(t, err)
+	wrapped := &eofInjectingFile{File: readFile}
+
+	// R(9) reads all 9 bytes and the wrapper injects io.EOF; the sequence must
+	// still reach C() and succeed.
+	contents, err := ExecuteSequence(t, wrapped, "R(9);C()")
+	require.NoError(t, err)
+	require.Equal(t, "some text", contents)
+}

--- a/backend/testsuite/io_conformance_test.go
+++ b/backend/testsuite/io_conformance_test.go
@@ -73,6 +73,24 @@ func (f *eofInjectingFile) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// shortReadEOFFile wraps a vfs.File and returns io.EOF alongside fewer bytes
+// than requested, simulating a genuine short read that happens to coincide
+// with EOF (as opposed to a fully-satisfied read that also signals EOF).
+type shortReadEOFFile struct {
+	vfs.File
+}
+
+func (f *shortReadEOFFile) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, io.EOF
+	}
+	n, err := f.File.Read(p[:1])
+	if err == nil {
+		return n, io.EOF
+	}
+	return n, err
+}
+
 // TestExecuteSequence_EOFOnFullRead verifies that a fixed-size read returning
 // io.EOF together with data is treated as a successful read: the sequence must
 // continue (so the trailing Close runs) and report no error.
@@ -94,4 +112,28 @@ func TestExecuteSequence_EOFOnFullRead(t *testing.T) {
 	contents, err := ExecuteSequence(t, wrapped, "R(9);C()")
 	require.NoError(t, err)
 	require.Equal(t, "some text", contents)
+}
+
+// TestExecuteSequence_ShortReadWithEOFIsAnError verifies that a short read
+// (fewer bytes than requested) accompanied by io.EOF is treated as a genuine
+// failure and is not masked by the "EOF on a fully-satisfied read" allowance.
+func TestExecuteSequence_ShortReadWithEOFIsAnError(t *testing.T) {
+	loc := newMemIOLocation(t)
+
+	seed, err := loc.NewFile("shortread.txt")
+	require.NoError(t, err)
+	_, err = seed.Write([]byte("some text"))
+	require.NoError(t, err)
+	require.NoError(t, seed.Close())
+
+	readFile, err := loc.NewFile("shortread.txt")
+	require.NoError(t, err)
+	wrapped := &shortReadEOFFile{File: readFile}
+
+	// R(9) requests 9 bytes but the wrapper only ever returns 1 byte at a time
+	// alongside io.EOF; this must be reported as an error, not silently
+	// forgiven and allowed to continue on to C().
+	_, err = ExecuteSequence(t, wrapped, "R(9);C()")
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.EOF)
 }


### PR DESCRIPTION
## Summary

Prepares the canonical `backend/testsuite` conformance suite so it can be reused by backends (and a future Testcontainers module, see #294) instead of being duplicated. Two changes:

### Added
- **`RunIOTests` now accepts optional `ConformanceOptions`** (the same options type already used by `RunConformanceTests`), so a backend can opt out of IO sequences it genuinely cannot support. `SkipFTPSpecificTests` skips the `Write, Seek, Write` (partial write) cases — FTP streams writes directly to the server and cannot rewind an in-progress write.
- The FTP `TestIOConformance` (`vfsintegration`) now passes `SkipFTPSpecificTests: true`; previously it had no way to, so those cases would fail against a real FTP server.

### Fixed
- **`ExecuteSequence` EOF handling.** A fixed-size read (`R(n)`) that returns `io.EOF` alongside the final bytes is a valid end-of-file condition on some backends. The sequence runner treated any error — including `io.EOF` — as fatal and aborted. It now recognizes `io.EOF` as a successful read and continues the sequence.

## Notes
- Reuses the existing `ConformanceOptions` struct rather than introducing a parallel `IOOptions` type, keeping one coherent options surface across the suite.
- The `RunIOTests` signature change is backward compatible (variadic), so existing callers (`mem`, `os`, `s3`, `gs`, `azure`, `sftp`, dropbox contrib) are unaffected.
- Skipped cases now use `t.Skip` (visible as skipped) rather than a silent early return.

## Testing
- `go build ./...`
- `go vet -tags=vfsintegration ./backend/ftp/... ./backend/testsuite/...`
- `go test -tags=vfsintegration -run TestConformance -run TestIOConformance ./backend/mem/... ./backend/os/...` — all IO sequences pass, including read-to-EOF cases (mem/os support partial writes, so `Write, Seek, Write` runs and passes there).
- `golangci-lint run --build-tags=vfsintegration ./backend/testsuite/... ./backend/ftp/...` — 0 issues.

Part of a series extracted from #294 (this is "PR B"; the Azure/FTP backend fixes landed in #346).

Made with [Cursor](https://cursor.com)