### PR TITLE
fix: stop testcontainers integration workflow from running on push to main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
   schedule:
     # Nightly run to catch upstream image/backend drift even without a PR.
     - cron: '0 7 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CI: `Integration (testcontainers)` (`integration.yml`) no longer triggers on `push` to `main`. It's a required status check on pull requests, but since it also ran on every push, `releasegen`'s post-merge CHANGELOG version-bump commit—brand new and necessarily lacking a check result at push time—was rejected by branch protection (`protected branch hook declined`), blocking all automated releases. It still runs on every PR and on the nightly schedule.
+
 ### Security
 - Updated Go version references from 1.25 to 1.26.7 in `go.mod`, `.golangci.yml`, and GitHub Actions workflows (`go.yml`, `golangci-lint.yml`, `go-test-coverage.yml`, `codeql.yml`) per the Go version policy in AGENTS.md, now that Go 1.27 has been released ([#352](https://github.com/C2FO/vfs/issues/352)).
 - Updated test matrix in `go.yml` to test Go 1.26 and 1.27 (latest-1 and latest minor versions) per VFS compatibility policy.


### PR DESCRIPTION
## Summary
- `testcontainers conformance` (`.github/workflows/integration.yml`) is a required status check on pull requests, but was also configured to run on `push` to `main`.
- That meant every direct push to `main` — including `releasegen`'s post-merge CHANGELOG version-bump commit — was rejected by branch protection: a brand-new commit can't already have a passing result for a required check at push time, so GitHub declined the push with `protected branch hook declined`, blocking all automated releases (confirmed with #354's release run: https://github.com/C2FO/vfs/actions/runs/33204224135).
- Removes the `push: branches: [main]` trigger. The workflow still runs on every PR (satisfying the required check) and on the nightly schedule.

## Test plan
- [x] `Validate CHANGELOG.md` prenup hook passed locally
- [ ] Confirm `testcontainers conformance` still runs on this PR
- [ ] After merge, confirm `releasegen` successfully creates the next release (no more `protected branch hook declined`)

Made with [Cursor](https://cursor.com)