### PR TITLE
test: revert create-github-app-token to v2.2.2 for releasegen

### DIFF
--- a/.github/workflows/releasegen.yml
+++ b/.github/workflows/releasegen.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.RELEASEGEN_APP_ID }}
           private-key: ${{ secrets.RELEASEGEN_APP_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- CI: Reverted `actions/create-github-app-token` from v3.2.0 to v2.2.2 in `releasegen.yml`. After the v3 bump, `releasegen`'s post-merge CHANGELOG version-bump push to `main` started failing with `protected branch hook declined` even with the required-status-check trigger issue fixed, suggesting the v3 upgrade changed how GitHub recognizes the `releasegen-bot` app's branch-protection bypass eligibility for the resulting installation token. Isolating this to confirm before deciding on a permanent fix.
 - CI: `Integration (testcontainers)` (`integration.yml`) no longer triggers on `push` to `main`. It's a required status check on pull requests, but since it also ran on every push, `releasegen`'s post-merge CHANGELOG version-bump commit—brand new and necessarily lacking a check result at push time—was rejected by branch protection (`protected branch hook declined`), blocking all automated releases. It still runs on every PR and on the nightly schedule.
 
 ### Security


### PR DESCRIPTION
## Summary
Experimental fix for the release automation deadlock that persisted after #355.

After #355 removed the `push` trigger from `integration.yml`, `releasegen`'s post-merge push to `main` **still** failed with `protected branch hook declined` (https://github.com/C2FO/vfs/actions/runs/33206311174/job/98968136063), and this time the merge commit had *zero* check-runs at all when the push was attempted — ruling out the "required check missing for this SHA" theory entirely.

The only other change bundled into the same PR (#354) that touches this exact push path is the `actions/create-github-app-token` v2.2.2 → v3.2.0 bump used to generate the token `releasegen` pushes with. This PR reverts that one action back to v2.2.2 to isolate whether the v3 upgrade changed how GitHub recognizes the `releasegen-bot` app's branch-protection bypass eligibility for the resulting installation token.

## Test plan
- [ ] Merge and confirm `releasegen` succeeds on the resulting push to `main` (no more `protected branch hook declined`)
- [ ] If it still fails, this isolates the cause elsewhere and we should revert this PR

Made with [Cursor](https://cursor.com)