### PR TITLE
ci: add golangci-lint (required) gate for the full lint matrix

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -69,3 +69,22 @@ jobs:
           # Optional: if set to true then the action will use pre-installed Go.
           # skip-go-installation: true
           working-directory: ${{ matrix.module }}
+
+  # Single required-status-check gate for the whole lint matrix. The matrix above
+  # fans out into a dynamic, ever-changing set of per-module checks that can't
+  # reasonably be enumerated in branch protection, so branch protection/rulesets
+  # should require only this job instead of every generated "golangci-lint (...)" check.
+  golangci-required:
+    name: golangci-lint (required)
+    needs: golangci
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify lint matrix succeeded
+        run: |
+          result="${{ needs.golangci.result }}"
+          echo "Lint matrix result: $result"
+          if [ "$result" != "success" ]; then
+            echo "One or more jobs in the lint matrix did not succeed."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CI: Added a `golangci-lint (required)` gate job to `golangci-lint.yml`, mirroring the `Test (required)` gate added for the `go.yml` test matrix. It depends on the entire per-module `golangci-lint` matrix and fails if any module didn't pass. Swapped it in as the required status check on `main` in place of `golangci-lint (.)`, which only covered the root module and didn't gate contrib modules or `testcontainers`.
+
 ## [[v7.27.0](https://github.com/C2FO/vfs/releases/tag/v7.27.0)] - 2026-08-28
 ### Added
 - CI: Added a `Test (required)` gate job to `go.yml` that depends on the entire `test` matrix (all modules/Go versions/OSes) and fails if any matrix job didn't succeed. Added it as a required status check on `main` in place of enumerating the matrix's dynamically-named per-job checks, which change whenever a module, Go version, or OS is added/removed and can't reasonably be listed individually in branch protection.


### PR DESCRIPTION
## Summary
- `golangci-lint.yml` fans out into a per-module matrix (`golangci-lint (<module>)`), but only `golangci-lint (.)` (the root module) was wired up as a required status check on `main`, so lint failures in contrib modules or `testcontainers` wouldn't block merges.
- Adds a `golangci-lint (required)` gate job, mirroring the `Test (required)` gate already added to `go.yml`: a single job that depends on the whole `golangci` matrix and fails if any module didn't pass.
- Swapped `golangci-lint (required)` into the `main-protection` ruleset's required status checks in place of `golangci-lint (.)`.

## Test plan
- [ ] CI green on this PR, including the new `golangci-lint (required)` job
- [x] `main-protection` ruleset updated via the GitHub API to require `golangci-lint (required)` instead of `golangci-lint (.)`