### PR TITLE
fix(vfsevents): drop deprecated cloud.google.com/go/pubsub v1 dependency

### DIFF
--- a/contrib/vfsevents/CHANGELOG.md
+++ b/contrib/vfsevents/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `gcsevents`: Regenerated the `mocks.PubSubClient` mock, which had been mockery-generated against the deprecated `cloud.google.com/go/pubsub` (v1) package and never updated when the watcher migrated to `cloud.google.com/go/pubsub/v2`. The `PubSubClient` interface itself already used the v2 `*pubsub.Message` type; only the generated mock's import was stale. Running `go mod tidy` now drops `cloud.google.com/go/pubsub` (v1) entirely, silencing its deprecation warning. Fixes [#360](https://github.com/C2FO/vfs/issues/360).
+
 ## [[contrib/vfsevents/v1.4.0](https://github.com/C2FO/vfs/releases/tag/contrib%2Fvfsevents%2Fv1.4.0)] - 2026-08-28
 ### Security
 - Updated Go version to 1.26.7 per the Go version policy in AGENTS.md ([#352](https://github.com/C2FO/vfs/issues/352)).

--- a/contrib/vfsevents/go.mod
+++ b/contrib/vfsevents/go.mod
@@ -3,7 +3,6 @@ module github.com/c2fo/vfs/contrib/vfsevents
 go 1.26.7
 
 require (
-	cloud.google.com/go/pubsub v1.51.1
 	cloud.google.com/go/pubsub/v2 v2.7.0
 	github.com/aws/aws-sdk-go-v2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/config v1.33.1

--- a/contrib/vfsevents/go.sum
+++ b/contrib/vfsevents/go.sum
@@ -11,16 +11,12 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.13.0 h1:ufT3FPT5rFFXu6UtLkNoxaOaV5EuA1dsSkmemCSTo6U=
 cloud.google.com/go/iam v1.13.0/go.mod h1:gHXdDEiPDvqd1q1KwBDGQlgZY/BwY760zU2LhOZS5w0=
-cloud.google.com/go/kms v1.31.0 h1:LS8N92OxFDgOLg5NCo3OmbvjtQAIVT5gUHVLKIDHaFE=
-cloud.google.com/go/kms v1.31.0/go.mod h1:YIyXZym11R5uovJJt4oN5eUL3oPmirF3yKeIh6QAf4U=
 cloud.google.com/go/logging v1.19.1 h1:7SsLhyTDBDrJw+Ll6Ns3I2mByqHXvJUc3rGjSlwiWgU=
 cloud.google.com/go/logging v1.19.1/go.mod h1:2IkQ/d8jVJqV2qW8ZUGUiMjdZG1gkLD2JReGbZ8isqg=
 cloud.google.com/go/longrunning v1.2.0 h1:WjYH3YHBGCxGJP9M4dWGHBfXr/cFIjMkNgWcJj7/iMM=
 cloud.google.com/go/longrunning v1.2.0/go.mod h1:5KMQALFGOCtFoi2xSOA1u3H7WKlhmckgiyFw7+LGQp0=
 cloud.google.com/go/monitoring v1.30.0 h1:r/d+JUbyKmJ8b07iznuKfzVzrIXTWxHQ3lBRm3x2LlY=
 cloud.google.com/go/monitoring v1.30.0/go.mod h1:htlUR0QWVMrjFzZmN4LGnMAve9xB/eduwjmINxVZ8RM=
-cloud.google.com/go/pubsub v1.51.1 h1:R3G1wCOxBO7jRpL8x2pdZMv1GAJDF6ax/m2zPOtvTNE=
-cloud.google.com/go/pubsub v1.51.1/go.mod h1:y2T0IKtW1iWwVvazYaRpqOAFO4gy2+O7dTDt9TWY/5U=
 cloud.google.com/go/pubsub/v2 v2.7.0 h1:MFrBTZZa6PDWZzCi4NJRsHKMm2w0a4oAaYNqwjgbQTE=
 cloud.google.com/go/pubsub/v2 v2.7.0/go.mod h1:JaFvWNVRk3Knoil/4M1ECeLOaI9D8drbmJWypQlK5aM=
 cloud.google.com/go/storage v1.66.0 h1:HwYx7m9Md/rzphAFshUeAWS3hNFsJQTgFrAu4RIRwpg=
@@ -205,8 +201,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-go.einride.tech/aip v0.83.0 h1:TI21IdeOnLTwZEJ3BxtImIZk6bsN2Q+sd0x99SLiQ+M=
-go.einride.tech/aip v0.83.0/go.mod h1:E8+wdTApA70odnpFzJgsGogHozC2JCIhFJBKPr8bVig=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/contrib/vfsevents/watchers/gcsevents/mocks/PubSubClient.go
+++ b/contrib/vfsevents/watchers/gcsevents/mocks/PubSubClient.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	"context"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	mock "github.com/stretchr/testify/mock"
 )
 


### PR DESCRIPTION
## Summary
Fixes #360.

The `gcsevents` watcher migrated to `cloud.google.com/go/pubsub/v2` a while back, but the mockery-generated `mocks.PubSubClient` mock was never regenerated and kept importing the deprecated v1 package for its `*pubsub.Message` parameter type. That stale import was the only thing keeping v1 in `go.mod` as a direct dependency, triggering:

```
go: module cloud.google.com/go/pubsub is deprecated: use cloud.google.com/go/pubsub/v2 instead.
```

The `PubSubClient` interface itself already used the v2 `*pubsub.Message` type - only the generated mock's import was stale.

## Changes
- Regenerated `contrib/vfsevents/watchers/gcsevents/mocks/PubSubClient.go` with `mockery` so it imports `cloud.google.com/go/pubsub/v2` instead of v1.
- Ran `go mod tidy` in `contrib/vfsevents`, which now drops `cloud.google.com/go/pubsub` (v1) entirely.
- Updated `contrib/vfsevents/CHANGELOG.md`.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test -race ./...` passes
- [x] `golangci-lint run` passes (0 new issues)
- [x] `prenup` pre-commit checks (tests, lint, changelog validation) passed locally
- [x] Confirmed `cloud.google.com/go/pubsub` (v1) no longer appears in `go.mod`/`go.sum`
- [ ] CI green on this PR